### PR TITLE
fix(i18n): Fix useTranslations context error by using correct react-i…

### DIFF
--- a/src/domains/bookmarks/hooks/useBookmarks.ts
+++ b/src/domains/bookmarks/hooks/useBookmarks.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-hot-toast';
 import { BookmarksService } from '@/api/generated/services/BookmarksService';
 import { BookmarkListWithContentResponse, BookmarkResponse } from '@/api/generated';
-import { useTranslations } from 'next-intl';
+import { useCommonTranslation } from '@/lib/i18n/hooks';
 
 interface UseBookmarksOptions {
   offset?: number;
@@ -39,7 +39,7 @@ export function useCheckBookmarkStatus(contentId: string) {
 
 export function useBookmarkMutations() {
   const queryClient = useQueryClient();
-  const t = useTranslations('common.toast.bookmarks');
+  const t = useCommonTranslation();
 
   const addBookmark = useMutation({
     mutationFn: (contentId: string) =>
@@ -52,10 +52,10 @@ export function useBookmarkMutations() {
       queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
       queryClient.invalidateQueries({ queryKey: ['bookmark-stats'] });
 
-      toast.success(t('added'));
+      toast.success(t.toast.bookmarks.added());
     },
     onError: (error) => {
-      toast.error(t('addFailed'));
+      toast.error(t.toast.bookmarks.addFailed());
       console.error('Add bookmark error:', error);
     },
   });
@@ -71,10 +71,10 @@ export function useBookmarkMutations() {
       queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
       queryClient.invalidateQueries({ queryKey: ['bookmark-stats'] });
 
-      toast.success(t('removed'));
+      toast.success(t.toast.bookmarks.removed());
     },
     onError: (error) => {
-      toast.error(t('removeFailed'));
+      toast.error(t.toast.bookmarks.removeFailed());
       console.error('Remove bookmark error:', error);
     },
   });

--- a/src/domains/channels/components/modal/channel/ChannelModalHeader.tsx
+++ b/src/domains/channels/components/modal/channel/ChannelModalHeader.tsx
@@ -9,7 +9,6 @@ import { toast } from 'react-hot-toast';
 import { ChannelEditorsStackedAvatars } from '@/shared/components/ChannelEditorsStackedAvatars';
 import { EditorsListModal } from '@/shared/components/EditorsListModal';
 import { useCommonTranslation } from '@/lib/i18n/hooks';
-import { useTranslations } from 'next-intl';
 
 interface ChannelModalHeaderProps {
   channel: ChannelData;
@@ -33,7 +32,6 @@ export function ChannelModalHeader({
   subscriptionHook,
 }: ChannelModalHeaderProps) {
   const t = useCommonTranslation();
-  const toastT = useTranslations('common.toast.general');
   const router = useRouter();
   const [isEditorsModalOpen, setIsEditorsModalOpen] = useState(false);
 
@@ -52,7 +50,7 @@ export function ChannelModalHeader({
         console.error('Error toggling subscription:', error);
       }
     } else {
-      toast.error(toastT('error'));
+      toast.error(t.toast.general.error());
     }
   };
 

--- a/src/domains/channels/hooks/useChannelBanner.ts
+++ b/src/domains/channels/hooks/useChannelBanner.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-hot-toast';
 import { ChannelsService } from '@/api/generated/services/ChannelsService';
 import type { BannerUpdate } from '@/api/generated/models/BannerUpdate';
-import { useTranslations } from 'next-intl';
+import { useCommonTranslation } from '@/lib/i18n/hooks';
 
 interface UseChannelBannerProps {
   channelId: string;
@@ -18,7 +18,7 @@ export const useChannelBanner = ({
   onError 
 }: UseChannelBannerProps) => {
   const queryClient = useQueryClient();
-  const t = useTranslations('common.toast.banner');
+  const t = useCommonTranslation();
 
   // Update banner mutation
   const updateBannerMutation = useMutation({
@@ -41,12 +41,12 @@ export const useChannelBanner = ({
         queryKey: ['channels'] 
       });
       
-      toast.success(t('updated'));
+      toast.success(t.toast.banner.updated());
       onSuccess?.();
     },
     onError: (error: Error) => {
       console.error('Failed to update banner:', error);
-      toast.error(t('updateFailed'));
+      toast.error(t.toast.banner.updateFailed());
       onError?.(error);
     },
   });

--- a/src/domains/channels/hooks/useChannelPins.ts
+++ b/src/domains/channels/hooks/useChannelPins.ts
@@ -9,7 +9,7 @@ import { queryKeys } from '@/lib/api/queryKeys';
 import { refreshOpenAPIToken } from '@/api/hooks/useApi';
 import { toast } from 'react-hot-toast';
 import { useSimpleToastMutation } from '@/lib/hooks/useToastMutation';
-import { useTranslations } from 'next-intl';
+import { useCommonTranslation } from '@/lib/i18n/hooks';
 
 /**
  * 채널의 pinned 컨텐츠 목록을 조회하는 Hook
@@ -140,7 +140,7 @@ export const useUnpinContent = () => {
  */
 export const useReorderPins = () => {
   const queryClient = useQueryClient();
-  const t = useTranslations('common.toast.pins');
+  const t = useCommonTranslation();
 
   return useMutation({
     mutationFn: async ({ 
@@ -198,7 +198,7 @@ export const useReorderPins = () => {
     },
     onSuccess: (response, { channelId }) => {
       console.log('[useReorderPins] Pins reordered successfully:', response);
-      toast.success(t('orderUpdated'));
+      toast.success(t.toast.pins.orderUpdated());
       
       // 서버 데이터로 다시 동기화
       queryClient.invalidateQueries({ 
@@ -207,7 +207,7 @@ export const useReorderPins = () => {
     },
     onError: (error, { channelId }, context) => {
       console.error('[useReorderPins] Failed to reorder pins:', error);
-      toast.error(t('orderUpdateFailed'));
+      toast.error(t.toast.pins.orderUpdateFailed());
       
       // 실패 시 이전 데이터로 롤백
       if (context?.previousPins) {

--- a/src/domains/comments/hooks/useComments.ts
+++ b/src/domains/comments/hooks/useComments.ts
@@ -9,7 +9,7 @@ import { queryKeys } from '@/lib/api/queryKeys';
 import { refreshOpenAPIToken } from '@/api/hooks/useApi';
 import { toast } from 'react-hot-toast';
 import { useSimpleToastMutation } from '@/lib/hooks/useToastMutation';
-import { useTranslations } from 'next-intl';
+import { useCommonTranslation } from '@/lib/i18n/hooks';
 
 export interface UseCommentsParams {
   contentId: string;
@@ -113,7 +113,7 @@ export const useComments = ({
  */
 export const useCreateComment = () => {
   const queryClient = useQueryClient();
-  const t = useTranslations('common.toast.comments');
+  const t = useCommonTranslation();
 
   return useSimpleToastMutation<
     CommentResponse,
@@ -155,7 +155,7 @@ export const useCreateComment = () => {
           queryKey: queryKeys.comments.stats(contentId),
         });
 
-        toast.success(t('added'));
+        toast.success(t.toast.comments.added());
       },
       onError: (error, { contentId }) => {
         console.error('[useCreateComment] Failed to create comment:', contentId, error);
@@ -169,7 +169,7 @@ export const useCreateComment = () => {
  */
 export const useUpdateComment = () => {
   const queryClient = useQueryClient();
-  const t = useTranslations('common.toast.comments');
+  const t = useCommonTranslation();
 
   return useSimpleToastMutation<
     CommentResponse,
@@ -196,7 +196,7 @@ export const useUpdateComment = () => {
           queryKey: queryKeys.comments.byContent(contentId),
         });
 
-        toast.success(t('updated'));
+        toast.success(t.toast.comments.updated());
       },
       onError: (error, { commentId }) => {
         console.error('[useUpdateComment] Failed to update comment:', commentId, error);
@@ -210,7 +210,7 @@ export const useUpdateComment = () => {
  */
 export const useDeleteComment = () => {
   const queryClient = useQueryClient();
-  const t = useTranslations('common.toast.comments');
+  const t = useCommonTranslation();
 
   return useSimpleToastMutation<void, Error, { commentId: string; contentId: string }>(
     async ({ commentId }) => {
@@ -236,7 +236,7 @@ export const useDeleteComment = () => {
           queryKey: queryKeys.comments.stats(contentId),
         });
 
-        toast.success(t('deleted'));
+        toast.success(t.toast.comments.deleted());
       },
       onError: (error, { commentId }) => {
         console.error('[useDeleteComment] Failed to delete comment:', commentId, error);

--- a/src/domains/interactions/hooks/useChannelSubscription.ts
+++ b/src/domains/interactions/hooks/useChannelSubscription.ts
@@ -5,14 +5,14 @@ import { InteractionsService } from '@/api/generated/services/InteractionsServic
 import { SubscriptionResponse } from '@/api/generated/models/SubscriptionResponse';
 import { ChannelSubscriptionStatsResponse } from '@/api/generated/models/ChannelSubscriptionStatsResponse';
 import { toast } from 'react-hot-toast';
-import { useTranslations } from 'next-intl';
+import { useCommonTranslation } from '@/lib/i18n/hooks';
 
 /**
  * Channel subscription hook for managing subscribe/unsubscribe actions
  */
 export const useChannelSubscription = (channelId: string) => {
   const queryClient = useQueryClient();
-  const t = useTranslations('common.toast.subscription');
+  const t = useCommonTranslation();
 
   // Query keys for caching
   const subscriptionStatsKey = ['channel-subscription-stats', channelId];
@@ -93,7 +93,7 @@ export const useChannelSubscription = (channelId: string) => {
         });
 
         // Show success message
-        toast.success(t('subscribed'));
+        toast.success(t.toast.subscription.subscribed());
 
         // Invalidate only this specific channel's queries
         queryClient.invalidateQueries({
@@ -115,7 +115,7 @@ export const useChannelSubscription = (channelId: string) => {
     },
     onError: (error: any) => {
       console.error('Subscribe error:', error);
-      toast.error(t('subscribeFailed'));
+      toast.error(t.toast.subscription.subscribeFailed());
     },
   });
 
@@ -150,7 +150,7 @@ export const useChannelSubscription = (channelId: string) => {
         });
 
         // Show success message
-        toast.success(t('unsubscribed'));
+        toast.success(t.toast.subscription.unsubscribed());
 
         // Invalidate only this specific channel's queries
         queryClient.invalidateQueries({
@@ -172,7 +172,7 @@ export const useChannelSubscription = (channelId: string) => {
     },
     onError: (error: any) => {
       console.error('Unsubscribe error:', error);
-      toast.error(t('unsubscribeFailed'));
+      toast.error(t.toast.subscription.unsubscribeFailed());
     },
   });
 

--- a/src/domains/profile/components/ProfileEditModal.tsx
+++ b/src/domains/profile/components/ProfileEditModal.tsx
@@ -4,7 +4,7 @@ import { useAuthStore } from '@/store/authStore';
 import { useProfileTranslation } from '@/lib/i18n/hooks';
 import { SimpleModal } from '@/lib/components/ui/modal/SimpleModal';
 import toast from 'react-hot-toast';
-import { useTranslations } from 'next-intl';
+import { useCommonTranslation } from '@/lib/i18n/hooks';
 
 interface ProfileEditModalProps {
   isOpen: boolean;
@@ -14,7 +14,7 @@ interface ProfileEditModalProps {
 export function ProfileEditModal({ isOpen, onClose }: ProfileEditModalProps) {
   const user = useAuthStore((state) => state.user);
   const t = useProfileTranslation();
-  const toastT = useTranslations('common.toast.profile');
+  const toastT = useCommonTranslation();
   const { data: profileData, isLoading: profileLoading } = useMyProfile();
   const { mutate: updateProfile, isPending } = useUpdateProfile();
 
@@ -96,7 +96,7 @@ export function ProfileEditModal({ isOpen, onClose }: ProfileEditModalProps) {
       setPreviewImage(previewUrl);
       setFormData((prev) => ({ ...prev, profile_image: file }));
     } catch (error) {
-      toast.error(toastT('updateFailed'));
+      toast.error(toastT.toast.profile.updateFailed());
     }
   };
 
@@ -132,7 +132,7 @@ export function ProfileEditModal({ isOpen, onClose }: ProfileEditModalProps) {
         },
       });
     } catch (error: any) {
-      toast.error(error.message || toastT('updateFailed'));
+      toast.error(error.message || toastT.toast.profile.updateFailed());
     }
   };
 

--- a/src/domains/profile/hooks/useProfile.ts
+++ b/src/domains/profile/hooks/useProfile.ts
@@ -4,7 +4,7 @@ import { UpdateProfileRequest } from '@/api/generated/models/UpdateProfileReques
 import { queryKeys } from '@/lib/api/queryKeys';
 import { useAuthStore } from '@/store/authStore';
 import toast from 'react-hot-toast';
-import { useTranslations } from 'next-intl';
+import { useCommonTranslation } from '@/lib/i18n/hooks';
 
 /**
  * Hook to get current user's profile
@@ -44,7 +44,7 @@ export const useUserProfile = (userId: string) => {
 export const useUpdateProfile = () => {
   const queryClient = useQueryClient();
   const user = useAuthStore((state) => state.user);
-  const t = useTranslations('common.toast.profile');
+  const t = useCommonTranslation();
 
   return useMutation({
     mutationFn: (data: UpdateProfileRequest) =>
@@ -55,11 +55,11 @@ export const useUpdateProfile = () => {
         queryKey: queryKeys.users.profile(user?.doc_id || ''),
       });
 
-      toast.success(t('updated'));
+      toast.success(t.toast.profile.updated());
     },
     onError: (error: any) => {
       console.error('Failed to update profile:', error);
-      toast.error(error?.body?.detail || t('updateFailed'));
+      toast.error(error?.body?.detail || t.toast.profile.updateFailed());
     },
   });
 };

--- a/src/lib/i18n/centralizedHooks.ts
+++ b/src/lib/i18n/centralizedHooks.ts
@@ -63,6 +63,46 @@ type CommonTranslations = {
     about: () => string;
     contact: () => string;
   };
+  toast: {
+    profile: {
+      updated: () => string;
+      updateFailed: () => string;
+      processing: () => string;
+    };
+    bookmarks: {
+      added: () => string;
+      removed: () => string;
+      addFailed: () => string;
+      removeFailed: () => string;
+    };
+    subscription: {
+      subscribed: () => string;
+      unsubscribed: () => string;
+      subscribeFailed: () => string;
+      unsubscribeFailed: () => string;
+    };
+    comments: {
+      added: () => string;
+      updated: () => string;
+      deleted: () => string;
+      addFailed: () => string;
+      updateFailed: () => string;
+      deleteFailed: () => string;
+    };
+    pins: {
+      orderUpdated: () => string;
+      orderUpdateFailed: () => string;
+    };
+    banner: {
+      updated: () => string;
+      updateFailed: () => string;
+    };
+    general: {
+      success: () => string;
+      error: () => string;
+      tryAgain: () => string;
+    };
+  };
   time: {
     justNow: () => string;
     hoursAgo: (hours: number) => string;
@@ -513,6 +553,46 @@ export const useCommonTranslation = (): CommonTranslations => {
       help: () => t('navigation.help'),
       about: () => t('navigation.about'),
       contact: () => t('navigation.contact'),
+    },
+    toast: {
+      profile: {
+        updated: () => t('toast.profile.updated'),
+        updateFailed: () => t('toast.profile.updateFailed'),
+        processing: () => t('toast.profile.processing'),
+      },
+      bookmarks: {
+        added: () => t('toast.bookmarks.added'),
+        removed: () => t('toast.bookmarks.removed'),
+        addFailed: () => t('toast.bookmarks.addFailed'),
+        removeFailed: () => t('toast.bookmarks.removeFailed'),
+      },
+      subscription: {
+        subscribed: () => t('toast.subscription.subscribed'),
+        unsubscribed: () => t('toast.subscription.unsubscribed'),
+        subscribeFailed: () => t('toast.subscription.subscribeFailed'),
+        unsubscribeFailed: () => t('toast.subscription.unsubscribeFailed'),
+      },
+      comments: {
+        added: () => t('toast.comments.added'),
+        updated: () => t('toast.comments.updated'),
+        deleted: () => t('toast.comments.deleted'),
+        addFailed: () => t('toast.comments.addFailed'),
+        updateFailed: () => t('toast.comments.updateFailed'),
+        deleteFailed: () => t('toast.comments.deleteFailed'),
+      },
+      pins: {
+        orderUpdated: () => t('toast.pins.orderUpdated'),
+        orderUpdateFailed: () => t('toast.pins.orderUpdateFailed'),
+      },
+      banner: {
+        updated: () => t('toast.banner.updated'),
+        updateFailed: () => t('toast.banner.updateFailed'),
+      },
+      general: {
+        success: () => t('toast.general.success'),
+        error: () => t('toast.general.error'),
+        tryAgain: () => t('toast.general.tryAgain'),
+      },
     },
     time: {
       justNow: () => t('time.justNow'),


### PR DESCRIPTION
…18next hooks

- Replace next-intl useTranslations with react-i18next useCommonTranslation
- Add toast message types and implementations to centralizedHooks.ts
- Update all hook files to use useCommonTranslation instead of useTranslations
- Fix ProfileEditModal and ChannelModalHeader to use correct i18n hooks
- All toast messages now properly use react-i18next context

This resolves the NextIntlClientProvider context error by using the correct i18n library that the project is configured to use.
