### PR TITLE
Release/pre launch cleanup

### DIFF
--- a/src/components/FallbackImage.tsx
+++ b/src/components/FallbackImage.tsx
@@ -12,6 +12,7 @@ interface FallbackImageProps {
   fallbackText?: string;
   className?: string;
   children?: React.ReactNode;
+  disableHover?: boolean;
 }
 
 // 타입별 기본 설정
@@ -101,6 +102,7 @@ export function FallbackImage({
   fallbackText,
   className,
   children,
+  disableHover = false,
 }: FallbackImageProps) {
   const config = typeConfig[type];
   const sizeClasses = sizeConfig[size];
@@ -140,9 +142,9 @@ export function FallbackImage({
 
         // 호버 효과 (선택사항)
         'transition-colors duration-200',
-        'hover:bg-[var(--color-primary-bg)]',
-        'hover:border-[var(--color-primary-bd)]',
-        'hover:text-[var(--color-primary)]',
+        !disableHover && 'hover:bg-[var(--color-primary-bg)]',
+        !disableHover && 'hover:border-[var(--color-primary-bd)]',
+        !disableHover && 'hover:text-[var(--color-primary)]',
 
         className,
       )}
@@ -178,9 +180,16 @@ export function AvatarFallback({
   fallbackText,
   size = 'md',
   className,
+  disableHover,
 }: Omit<FallbackImageProps, 'type'>) {
   return (
-    <FallbackImage type="avatar" size={size} fallbackText={fallbackText} className={className} />
+    <FallbackImage
+      type="avatar"
+      size={size}
+      fallbackText={fallbackText}
+      className={className}
+      disableHover={disableHover}
+    />
   );
 }
 

--- a/src/domains/channels/components/modal/base/BaseModal.tsx
+++ b/src/domains/channels/components/modal/base/BaseModal.tsx
@@ -25,6 +25,9 @@ interface BaseModalProps {
   descId?: string;
   onEscape?: () => void;
   onOverlayClick?: () => void;
+  // 새로운 구조 지원을 위한 props
+  legacyMode?: boolean; // 하위 호환성 플래그
+  enableFlexLayout?: boolean; // 새로운 flex 레이아웃 활성화
 }
 
 export function BaseModal({
@@ -41,6 +44,8 @@ export function BaseModal({
   descId,
   onEscape,
   onOverlayClick,
+  legacyMode = false,
+  enableFlexLayout = true,
 }: BaseModalProps) {
   const [mounted, setMounted] = useState(false);
   const modalRootRef = useRef<HTMLDivElement | null>(null);
@@ -92,15 +97,23 @@ export function BaseModal({
     return null;
   }
 
+  // 레이아웃 모드 결정
+  const useFlexLayout = enableFlexLayout && !legacyMode;
+
+  // 다이얼로그 클래스 결정
+  const dialogClasses = useFlexLayout
+    ? `relative ${Z_INDEX_CLASSES.MODAL_CONTENT} ${contentClassName} max-h-[80vh] flex flex-col ${className}`
+    : `relative ${Z_INDEX_CLASSES.MODAL_CONTENT} ${contentClassName} max-h-[80vh] overflow-y-auto ${className}`;
+
   const node = (
     <div
       className={`fixed inset-0 ${Z_INDEX_CLASSES.MODAL_OVERLAY} flex items-center justify-center ${
         isMobile ? 'p-0' : 'p-2 sm:p-4'
       }`}
-      style={{ 
+      style={{
         backdropFilter: 'blur(8px)',
         paddingTop: isMobile ? '0' : 'max(1rem, min(5rem, 20vh))',
-        paddingBottom: isMobile ? '0' : 'max(1rem, min(5rem, 20vh))'
+        paddingBottom: isMobile ? '0' : 'max(1rem, min(5rem, 20vh))',
       }}
       role="presentation"
       onClick={(e) => {
@@ -126,7 +139,7 @@ export function BaseModal({
         aria-modal="true"
         aria-labelledby={titleId}
         aria-describedby={descId}
-        className={`relative ${Z_INDEX_CLASSES.MODAL_CONTENT} ${contentClassName} max-h-[80vh] overflow-y-auto ${className}`}
+        className={dialogClasses}
         style={{ maxHeight: '80vh' }}
         // 모달 내부 클릭은 버블링 중단(backdrop 클릭 닫기와 충돌 방지)
         onClick={(e) => e.stopPropagation()}

--- a/src/domains/channels/components/modal/channel/ChannelModal.tsx
+++ b/src/domains/channels/components/modal/channel/ChannelModal.tsx
@@ -68,6 +68,7 @@ export function ChannelModal() {
       closeOnEscape={!isContentModalOpen}
       titleId="channel-modal-title"
       descId="channel-modal-description"
+      enableFlexLayout={true}
     >
       <ChannelModalContainer>
         {/* Header */}

--- a/src/domains/channels/components/modal/content/ContentModal.tsx
+++ b/src/domains/channels/components/modal/content/ContentModal.tsx
@@ -35,6 +35,7 @@ export function ContentModal() {
         onClose={closeModal}
         closeOnOverlayClick={true}
         closeOnEscape={true}
+        enableFlexLayout={true}
       >
         <div className="flex relative w-full h-full">
           {/* Left: Original Content Modal */}

--- a/src/domains/channels/components/modal/content/MobileCardLayout.tsx
+++ b/src/domains/channels/components/modal/content/MobileCardLayout.tsx
@@ -6,12 +6,12 @@ interface MobileCardLayoutProps {
   onClose?: () => void;
 }
 
-// 모바일 전용 카드 레이아웃 - 이미지 참고 디자인
+// 모바일 전용 카드 레이아웃 - 새로운 모달 구조 적용
 export function MobileCardLayout({ children, title, onClose }: MobileCardLayoutProps) {
   return (
     <div className="bg-zinc-900 rounded-none border-none shadow-2xl h-full w-full flex flex-col">
-      {/* Header with title and close button */}
-      <div className="flex items-center justify-between p-4 pt-6 border-b border-zinc-700/30">
+      {/* Header with title and close button - 고정 헤더 */}
+      <div className="flex-shrink-0 flex items-center justify-between p-4 pt-6 border-b border-zinc-700/30">
         <div>
           <h1 className="text-lg font-semibold text-white">{title || 'Content'}</h1>
         </div>
@@ -43,8 +43,8 @@ export function MobileCardLayout({ children, title, onClose }: MobileCardLayoutP
         )}
       </div>
 
-      {/* Main content area */}
-      <div className="flex-1 p-4 overflow-y-auto">{children}</div>
+      {/* Main content area - 스크롤 가능한 콘텐츠 */}
+      <div className="flex-1 p-4 overflow-y-auto min-h-0">{children}</div>
     </div>
   );
 }

--- a/src/domains/create/components/modal/add-channel/AddChannelModal.tsx
+++ b/src/domains/create/components/modal/add-channel/AddChannelModal.tsx
@@ -191,6 +191,7 @@ export function AddChannelModal() {
       closeOnEscape={true}
       titleId="add-channel-modal-title"
       descId="add-channel-modal-description"
+      enableFlexLayout={true}
     >
       <div className="bg-zinc-900/95 backdrop-blur-xl border border-zinc-700/50 rounded-2xl w-full max-w-[95vw] sm:max-w-[90vw] md:max-w-[1200px] lg:max-w-[1200px] max-h-[90vh] sm:max-h-[85vh] md:max-h-[90vh] overflow-hidden animate-scale-in shadow-2xl flex flex-col">
         <AddChannelHeader onClose={closeModal} currentStep={currentStep} />

--- a/src/domains/create/components/modal/base/BaseModal.tsx
+++ b/src/domains/create/components/modal/base/BaseModal.tsx
@@ -23,6 +23,9 @@ interface BaseModalProps {
   descId?: string;
   onEscape?: () => void;
   onOverlayClick?: () => void;
+  // 새로운 구조 지원을 위한 props
+  legacyMode?: boolean; // 하위 호환성 플래그
+  enableFlexLayout?: boolean; // 새로운 flex 레이아웃 활성화
 }
 
 export function BaseModal({
@@ -39,6 +42,8 @@ export function BaseModal({
   descId,
   onEscape,
   onOverlayClick,
+  legacyMode = false,
+  enableFlexLayout = true,
 }: BaseModalProps) {
   const [mounted, setMounted] = useState(false);
   const modalRootRef = useRef<HTMLDivElement | null>(null);
@@ -83,13 +88,21 @@ export function BaseModal({
     return null;
   }
 
+  // 레이아웃 모드 결정
+  const useFlexLayout = enableFlexLayout && !legacyMode;
+
+  // 다이얼로그 클래스 결정
+  const dialogClasses = useFlexLayout
+    ? `relative ${Z_INDEX_CLASSES.MODAL_CONTENT} max-h-[80vh] flex flex-col ${className}`
+    : `relative ${Z_INDEX_CLASSES.MODAL_CONTENT} max-h-[80vh] overflow-y-auto ${className}`;
+
   const node = (
     <div
       className={`fixed inset-0 ${Z_INDEX_CLASSES.MODAL_OVERLAY} flex items-center justify-center p-2 sm:p-4`}
-      style={{ 
+      style={{
         backdropFilter: 'blur(8px)',
         paddingTop: 'max(1rem, min(5rem, 20vh))',
-        paddingBottom: 'max(1rem, min(5rem, 20vh))'
+        paddingBottom: 'max(1rem, min(5rem, 20vh))',
       }}
       role="presentation"
     >
@@ -118,7 +131,7 @@ export function BaseModal({
         aria-modal="true"
         aria-labelledby={titleId}
         aria-describedby={descId}
-        className={`relative ${Z_INDEX_CLASSES.MODAL_CONTENT} max-h-[80vh] overflow-y-auto ${className}`}
+        className={dialogClasses}
         style={{ maxHeight: '80vh' }}
         // 모달 내부 클릭은 버블링 중단(backdrop 클릭 닫기와 충돌 방지)
         onClick={(e) => e.stopPropagation()}

--- a/src/domains/create/components/modal/base/ModalComponents.tsx
+++ b/src/domains/create/components/modal/base/ModalComponents.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React, { ReactNode } from 'react';
+
+interface ModalHeaderProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function ModalHeader({ children, className = '' }: ModalHeaderProps) {
+  return (
+    <div className={`flex-shrink-0 border-b border-gray-200 p-4 ${className}`}>{children}</div>
+  );
+}
+
+interface ModalContentProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function ModalContent({ children, className = '' }: ModalContentProps) {
+  return <div className={`flex-1 overflow-y-auto p-4 ${className}`}>{children}</div>;
+}
+
+interface ModalFooterProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function ModalFooter({ children, className = '' }: ModalFooterProps) {
+  return (
+    <div className={`flex-shrink-0 border-t border-gray-200 p-4 ${className}`}>{children}</div>
+  );
+}

--- a/src/domains/create/components/modal/base/index.ts
+++ b/src/domains/create/components/modal/base/index.ts
@@ -1,0 +1,2 @@
+export { BaseModal } from './BaseModal';
+export { ModalHeader, ModalContent, ModalFooter } from './ModalComponents';

--- a/src/shared/components/UserAvatar.tsx
+++ b/src/shared/components/UserAvatar.tsx
@@ -97,14 +97,19 @@ export function UserAvatar({ size = 'md', showDropdown = true }: UserAvatarProps
         onClick={() => showDropdown && setIsDropdownOpen(!isDropdownOpen)}
         className={`
           ${sizeClasses[size]}
-          relative transition-all duration-200
+          relative transition-all duration-200 rounded-full
           hover:ring-2 hover:ring-[var(--color-primary)] hover:ring-offset-2 hover:ring-offset-[var(--color-background)]
           ${showDropdown ? 'cursor-pointer' : 'cursor-default'}
         `}
         aria-label={t('user.userMenu')}
       >
         {/* Avatar with design system fallback */}
-        <AvatarFallback size={size} fallbackText={getInitials()} className="w-full h-full" />
+        <AvatarFallback
+          size={size}
+          fallbackText={getInitials()}
+          className="w-full h-full"
+          disableHover={true}
+        />
 
         {/* Online indicator */}
         <span className="absolute bottom-0 right-0 w-3 h-3 bg-green-500 border-2 border-[var(--color-background)] rounded-full" />


### PR DESCRIPTION
- Add enableFlexLayout and legacyMode props to BaseModal components
- Implement new modal structure with fixed header/footer and scrollable content
- Create ModalHeader, ModalContent, ModalFooter helper components
- Update existing modals to use new flex layout:
  - AddChannelModal: enableFlexLayout={true}
  - ContentModal: enableFlexLayout={true}
  - ChannelModal: enableFlexLayout={true}
- Improve MobileCardLayout with proper flex structure:
  - Fixed header with title and close button
  - Scrollable content area with min-h-0
  - Maintains mobile-specific dark theme design
- Ensure backward compatibility with legacyMode flag
- All modals now have consistent header/footer behavior
- Content area scrolls independently from fixed elements

- Add disableHover prop to prevent hover effects when needed
- Update UserAvatar to disable hover on AvatarFallback to prevent double hover effects
- Maintain existing hover behavior for other use cases