### PR TITLE
feat: add Vercel Speed Insights for performance monitoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@tanstack/react-query-devtools": "^5.83.0",
     "@types/matter-js": "^0.19.8",
     "@types/three": "^0.178.1",
+    "@vercel/speed-insights": "^1.2.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "fast-deep-equal": "^3.1.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Metadata } from 'next';
 import { cookies } from 'next/headers';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 import { QueryProvider } from '../lib/providers/QueryProvider';
 import { ToastProvider } from '../lib/providers/ToastProvider';
@@ -67,6 +68,7 @@ export default async function RootLayout({
             </PerformanceProvider>
           </QueryProvider>
         </I18nProvider>
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1293,7 +1293,7 @@ __metadata:
 
 "@decoded/ui@file:packages/ui::locator=decoded-app%40workspace%3A.":
   version: 0.1.1
-  resolution: "@decoded/ui@file:packages/ui#packages/ui::hash=be6498&locator=decoded-app%40workspace%3A."
+  resolution: "@decoded/ui@file:packages/ui#packages/ui::hash=dbc530&locator=decoded-app%40workspace%3A."
   dependencies:
     "@radix-ui/react-dialog": "npm:^1.1.15"
     "@radix-ui/react-dropdown-menu": "npm:^2.0.6"
@@ -1308,7 +1308,7 @@ __metadata:
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
     tailwindcss: ">=3.0.0"
-  checksum: 10c0/9b43687c072c6248e14eede9be6efcf04efaa618d3657d0b66db6875e4e35c1b1a6ae969ec1c32b0e158bf72ab2934690863c43b80f43d8d1852c4058842b0fc
+  checksum: 10c0/9d0915cb6118ae3956fd69f4ab3594a0b72dab3b4f179f3f1ee97a381fe3fee58b9e7bd488cc7471bd3e9e6c6d910c2bd947edb584461840073dd88aa6357ec6
   languageName: node
   linkType: hard
 
@@ -4444,6 +4444,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vercel/speed-insights@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@vercel/speed-insights@npm:1.2.0"
+  peerDependencies:
+    "@sveltejs/kit": ^1 || ^2
+    next: ">= 13"
+    react: ^18 || ^19 || ^19.0.0-rc
+    svelte: ">= 4"
+    vue: ^3
+    vue-router: ^4
+  peerDependenciesMeta:
+    "@sveltejs/kit":
+      optional: true
+    next:
+      optional: true
+    react:
+      optional: true
+    svelte:
+      optional: true
+    vue:
+      optional: true
+    vue-router:
+      optional: true
+  checksum: 10c0/2fb4c4a46330949182d6f63691c51310b636fc3cc464bde3c0f24f100b712c3c4ec57a9fedcd6dc3cc75951064b3295b3cb616c80ff7179fbe310cd4314fffaa
+  languageName: node
+  linkType: hard
+
 "@webgpu/types@npm:*":
   version: 0.1.64
   resolution: "@webgpu/types@npm:0.1.64"
@@ -5401,6 +5428,7 @@ __metadata:
     "@types/react-dom": "npm:^19.1.6"
     "@types/sharp": "npm:^0.32.0"
     "@types/three": "npm:^0.178.1"
+    "@vercel/speed-insights": "npm:^1.2.0"
     autoprefixer: "npm:^10.4.21"
     clsx: "npm:^2.1.1"
     date-fns: "npm:^4.1.0"


### PR DESCRIPTION
- Install @vercel/speed-insights package
- Add SpeedInsights component to root layout
- Enable Core Web Vitals monitoring
- Track real user performance metrics