### PR TITLE
feat: editorial page, magazine API, social actions (like/save/comment), image detail enhancements

### DIFF
--- a/packages/web/app/api/v1/post-magazines/[id]/route.ts
+++ b/packages/web/app/api/v1/post-magazines/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.API_BASE_URL;
+
+type RouteParams = {
+  params: Promise<{ id: string }>;
+};
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  if (!API_BASE_URL) {
+    console.error("API_BASE_URL environment variable is not configured");
+    return NextResponse.json(
+      { message: "Server configuration error" },
+      { status: 500 }
+    );
+  }
+
+  const { id } = await params;
+
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/api/v1/post-magazines/${id}`,
+      {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("PostMagazine GET proxy error:", error);
+    return NextResponse.json(
+      { message: "Failed to fetch post magazine" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/web/app/api/v1/posts/[postId]/likes/route.ts
+++ b/packages/web/app/api/v1/posts/[postId]/likes/route.ts
@@ -1,0 +1,104 @@
+/**
+ * Post Likes Proxy API Route
+ * GET /api/v1/posts/[postId]/likes - Get like stats (optional auth)
+ * POST /api/v1/posts/[postId]/likes - Like post (auth required)
+ * DELETE /api/v1/posts/[postId]/likes - Unlike post (auth required)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.API_BASE_URL;
+
+type RouteParams = {
+  params: Promise<{ postId: string }>;
+};
+
+async function proxy(
+  postId: string,
+  request: NextRequest,
+  method: "GET" | "POST" | "DELETE"
+) {
+  if (!API_BASE_URL) {
+    return NextResponse.json(
+      { message: "Server configuration error" },
+      { status: 500 }
+    );
+  }
+
+  const url = `${API_BASE_URL}/api/v1/posts/${postId}/likes`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  const authHeader = request.headers.get("Authorization");
+  if (authHeader) {
+    headers["Authorization"] = authHeader;
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers,
+  });
+
+  if (response.status === 204) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const data = await response.json();
+  return NextResponse.json(data, { status: response.status });
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { postId } = await params;
+  try {
+    return proxy(postId, request, "GET");
+  } catch (error) {
+    console.error("Likes GET proxy error:", error);
+    return NextResponse.json(
+      { message: "Failed to fetch like stats" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader) {
+    return NextResponse.json(
+      { message: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  const { postId } = await params;
+  try {
+    return proxy(postId, request, "POST");
+  } catch (error) {
+    console.error("Likes POST proxy error:", error);
+    return NextResponse.json(
+      { message: "Failed to like post" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader) {
+    return NextResponse.json(
+      { message: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  const { postId } = await params;
+  try {
+    return proxy(postId, request, "DELETE");
+  } catch (error) {
+    console.error("Likes DELETE proxy error:", error);
+    return NextResponse.json(
+      { message: "Failed to unlike post" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/web/app/api/v1/posts/[postId]/route.ts
+++ b/packages/web/app/api/v1/posts/[postId]/route.ts
@@ -28,10 +28,18 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
   const { postId } = await params;
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  const authHeader = request.headers.get("Authorization");
+  if (authHeader) {
+    headers["Authorization"] = authHeader;
+  }
+
   try {
     const response = await fetch(`${API_BASE_URL}/api/v1/posts/${postId}`, {
       method: "GET",
-      headers: { "Content-Type": "application/json" },
+      headers,
     });
 
     const data = await response.json();

--- a/packages/web/app/api/v1/posts/[postId]/saved/route.ts
+++ b/packages/web/app/api/v1/posts/[postId]/saved/route.ts
@@ -1,0 +1,104 @@
+/**
+ * Saved Posts Proxy API Route
+ * GET /api/v1/posts/[postId]/saved - Get save status (optional auth)
+ * POST /api/v1/posts/[postId]/saved - Save post (auth required)
+ * DELETE /api/v1/posts/[postId]/saved - Unsave post (auth required)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.API_BASE_URL;
+
+type RouteParams = {
+  params: Promise<{ postId: string }>;
+};
+
+async function proxy(
+  postId: string,
+  request: NextRequest,
+  method: "GET" | "POST" | "DELETE"
+) {
+  if (!API_BASE_URL) {
+    return NextResponse.json(
+      { message: "Server configuration error" },
+      { status: 500 }
+    );
+  }
+
+  const url = `${API_BASE_URL}/api/v1/posts/${postId}/saved`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  const authHeader = request.headers.get("Authorization");
+  if (authHeader) {
+    headers["Authorization"] = authHeader;
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers,
+  });
+
+  if (response.status === 204) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const data = await response.json();
+  return NextResponse.json(data, { status: response.status });
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { postId } = await params;
+  try {
+    return proxy(postId, request, "GET");
+  } catch (error) {
+    console.error("Saved GET proxy error:", error);
+    return NextResponse.json(
+      { message: "Failed to fetch save status" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader) {
+    return NextResponse.json(
+      { message: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  const { postId } = await params;
+  try {
+    return proxy(postId, request, "POST");
+  } catch (error) {
+    console.error("Saved POST proxy error:", error);
+    return NextResponse.json(
+      { message: "Failed to save post" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader) {
+    return NextResponse.json(
+      { message: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  const { postId } = await params;
+  try {
+    return proxy(postId, request, "DELETE");
+  } catch (error) {
+    console.error("Saved DELETE proxy error:", error);
+    return NextResponse.json(
+      { message: "Failed to unsave post" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/web/app/editorial/page.tsx
+++ b/packages/web/app/editorial/page.tsx
@@ -1,0 +1,5 @@
+import { ExploreClient } from "../explore/ExploreClient";
+
+export default function EditorialPage() {
+  return <ExploreClient hasMagazine />;
+}

--- a/packages/web/app/explore/ExploreClient.tsx
+++ b/packages/web/app/explore/ExploreClient.tsx
@@ -17,6 +17,8 @@ import { LoadingSpinner } from "@/lib/design-system";
 
 type Props = {
   initialPosts?: PostGridItem[];
+  /** magazine_id가 있는 post만 표시 (Editorial 탭용) */
+  hasMagazine?: boolean;
 };
 
 /**
@@ -26,7 +28,7 @@ type Props = {
  * - GET /api/v1/posts with pagination
  * - Supports category filtering via API params
  */
-export function ExploreClient({ initialPosts: _initialPosts }: Props) {
+export function ExploreClient({ initialPosts: _initialPosts, hasMagazine }: Props) {
   const activeFilter = useFilterStore((state) => state.activeFilter);
   const debouncedQuery = useSearchStore((state) => state.debouncedQuery);
   const [filterSheetOpen, setFilterSheetOpen] = useState(false);
@@ -62,6 +64,7 @@ export function ExploreClient({ initialPosts: _initialPosts }: Props) {
   } = useInfinitePosts({
     limit: 40,
     category: activeFilter,
+    hasMagazine: hasMagazine ?? false,
     // Note: search is not directly supported by Posts API
     // If needed, we can add artist_name or group_name filter
   });
@@ -82,8 +85,9 @@ export function ExploreClient({ initialPosts: _initialPosts }: Props) {
         postSource: item.postSource,
         postAccount: item.postAccount,
         postCreatedAt: item.postCreatedAt,
+        ...(hasMagazine && item.title && { editorialTitle: item.title }),
       }));
-  }, [items]);
+  }, [items, hasMagazine]);
 
   // Render full-screen ThiingsGrid with filter bar
   return (

--- a/packages/web/lib/api/adapters/postDetailToImageDetail.ts
+++ b/packages/web/lib/api/adapters/postDetailToImageDetail.ts
@@ -13,6 +13,19 @@ export type ImageDetailWithPostOwner = ImageDetail & {
   post_owner_id?: string | null;
   /** 포스트 생성 시 솔루션을 알고 등록했는지 */
   created_with_solutions?: boolean | null;
+  /** 연결된 Post Magazine ID */
+  post_magazine_id?: string | null;
+  /** AI가 생성한 포스트 요약 */
+  ai_summary?: string | null;
+  /** 아티스트/그룹명 (태그용) */
+  artist_name?: string | null;
+  group_name?: string | null;
+  /** 좋아요 개수 */
+  like_count?: number;
+  /** 현재 사용자가 좋아요 했는지 */
+  user_has_liked?: boolean | null;
+  /** 현재 사용자가 저장했는지 */
+  user_has_saved?: boolean | null;
 };
 
 function parsePosition(val: string): number {
@@ -60,7 +73,7 @@ export function postDetailToImageDetail(
         scores: null,
         ambiguity: null,
         citations,
-        metadata: null,
+        metadata: (top?.metadata as any) ?? null,
         sam_prompt: null,
       };
     }
@@ -71,7 +84,14 @@ export function postDetailToImageDetail(
     image_hash: "",
     image_url: post.image_url,
     post_owner_id: post.user?.id ?? null,
+    like_count: post.like_count ?? 0,
+    user_has_liked: post.user_has_liked ?? false,
+    user_has_saved: post.user_has_saved ?? false,
     created_with_solutions: post.created_with_solutions ?? null,
+    post_magazine_id: post.post_magazine_id ?? null,
+    ai_summary: post.ai_summary ?? null,
+    artist_name: post.artist_name ?? null,
+    group_name: post.group_name ?? null,
     status: post.status as
       | "pending"
       | "extracted"

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -69,12 +69,14 @@ export async function apiClient<T>(options: ApiClientOptions): Promise<T> {
     requestHeaders["Content-Type"] = "application/json";
   }
 
-  // Add Authorization header if required
+  // Add Authorization header if required, or when token available (optional auth)
+  const token = await getAuthToken();
   if (requiresAuth) {
-    const token = await getAuthToken();
     if (!token) {
       throw new Error("로그인이 필요합니다.");
     }
+    requestHeaders["Authorization"] = `Bearer ${token}`;
+  } else if (token) {
     requestHeaders["Authorization"] = `Bearer ${token}`;
   }
 

--- a/packages/web/lib/api/comments.ts
+++ b/packages/web/lib/api/comments.ts
@@ -1,0 +1,54 @@
+import { apiClient } from "./client";
+
+export interface CommentUser {
+  id: string;
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  rank: string;
+}
+
+export interface CommentResponse {
+  id: string;
+  post_id: string;
+  user_id: string;
+  parent_id: string | null;
+  content: string;
+  user: CommentUser;
+  created_at: number;
+  updated_at: number;
+  replies: CommentResponse[];
+}
+
+export interface CreateCommentDto {
+  content: string;
+  parent_id?: string | null;
+}
+
+export async function fetchComments(
+  postId: string
+): Promise<CommentResponse[]> {
+  return apiClient<CommentResponse[]>({
+    path: `/api/v1/posts/${postId}/comments`,
+  });
+}
+
+export async function createComment(
+  postId: string,
+  dto: CreateCommentDto
+): Promise<CommentResponse> {
+  return apiClient<CommentResponse>({
+    path: `/api/v1/posts/${postId}/comments`,
+    method: "POST",
+    body: dto,
+    requiresAuth: true,
+  });
+}
+
+export async function deleteComment(commentId: string): Promise<void> {
+  return apiClient<void>({
+    path: `/api/v1/comments/${commentId}`,
+    method: "DELETE",
+    requiresAuth: true,
+  });
+}

--- a/packages/web/lib/api/postLikes.ts
+++ b/packages/web/lib/api/postLikes.ts
@@ -1,0 +1,32 @@
+import { apiClient } from "./client";
+
+export interface PostLikeStatsResponse {
+  like_count: number;
+  user_has_liked: boolean;
+}
+
+export async function fetchPostLikeStats(
+  postId: string
+): Promise<PostLikeStatsResponse> {
+  return apiClient<PostLikeStatsResponse>({
+    path: `/api/v1/posts/${postId}/likes`,
+    method: "GET",
+    requiresAuth: false,
+  });
+}
+
+export async function createPostLike(postId: string): Promise<void> {
+  await apiClient<void>({
+    path: `/api/v1/posts/${postId}/likes`,
+    method: "POST",
+    requiresAuth: true,
+  });
+}
+
+export async function deletePostLike(postId: string): Promise<void> {
+  await apiClient<void>({
+    path: `/api/v1/posts/${postId}/likes`,
+    method: "DELETE",
+    requiresAuth: true,
+  });
+}

--- a/packages/web/lib/api/posts.ts
+++ b/packages/web/lib/api/posts.ts
@@ -20,6 +20,7 @@ import {
   UpdatePostDto,
   PostResponse,
   PostDetailResponse,
+  PostMagazineResponse,
   ApiError,
 } from "./types";
 
@@ -404,6 +405,8 @@ function buildPostsQueryString(params?: PostsListParams): string {
     searchParams.set("per_page", String(params.per_page));
   if (params.has_solutions !== undefined)
     searchParams.set("has_solutions", String(params.has_solutions));
+  if (params.has_magazine !== undefined)
+    searchParams.set("has_magazine", String(params.has_magazine));
 
   const queryString = searchParams.toString();
   return queryString ? `?${queryString}` : "";
@@ -432,8 +435,9 @@ export async function fetchPostsServer(
   params?: PostsListParams
 ): Promise<PostsListResponse> {
   const queryString = buildPostsQueryString(params);
+  const serverApiBase = process.env.API_BASE_URL || API_BASE_URL;
 
-  const response = await fetch(`${API_BASE_URL}/api/v1/posts${queryString}`, {
+  const response = await fetch(`${serverApiBase}/api/v1/posts${queryString}`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -468,6 +472,21 @@ export async function fetchPostDetail(
 ): Promise<PostDetailResponse> {
   return apiClient<PostDetailResponse>({
     path: `/api/v1/posts/${postId}`,
+    method: "GET",
+    requiresAuth: false,
+  });
+}
+
+// ============================================================
+// Fetch Post Magazine
+// GET /api/v1/post-magazines/{magazineId}
+// ============================================================
+
+export async function fetchPostMagazine(
+  magazineId: string
+): Promise<PostMagazineResponse> {
+  return apiClient<PostMagazineResponse>({
+    path: `/api/v1/post-magazines/${magazineId}`,
     method: "GET",
     requiresAuth: false,
   });

--- a/packages/web/lib/api/savedPosts.ts
+++ b/packages/web/lib/api/savedPosts.ts
@@ -1,0 +1,31 @@
+import { apiClient } from "./client";
+
+export interface SavedPostStatsResponse {
+  user_has_saved: boolean;
+}
+
+export async function fetchSavedPostStatus(
+  postId: string
+): Promise<SavedPostStatsResponse> {
+  return apiClient<SavedPostStatsResponse>({
+    path: `/api/v1/posts/${postId}/saved`,
+    method: "GET",
+    requiresAuth: false,
+  });
+}
+
+export async function savePost(postId: string): Promise<void> {
+  await apiClient<void>({
+    path: `/api/v1/posts/${postId}/saved`,
+    method: "POST",
+    requiresAuth: true,
+  });
+}
+
+export async function unsavePost(postId: string): Promise<void> {
+  await apiClient<void>({
+    path: `/api/v1/posts/${postId}/saved`,
+    method: "DELETE",
+    requiresAuth: true,
+  });
+}

--- a/packages/web/lib/api/types.ts
+++ b/packages/web/lib/api/types.ts
@@ -194,6 +194,8 @@ export interface Post {
   image_url: string;
   media_source: PostMediaSource | null;
   title: string | null;
+  /** 에디토리얼(매거진) 타이틀. post_magazine_id가 있을 때만 반환 */
+  post_magazine_title?: string | null;
   artist_name: string | null;
   group_name: string | null;
   context: string | null;
@@ -226,6 +228,8 @@ export interface PostsListParams {
   per_page?: number;
   /** true = 솔루션 있는 post만, false = spot은 있으나 솔루션 없는 post만 */
   has_solutions?: boolean;
+  /** true = post_magazine_id가 있는 post만 (editorial) */
+  has_magazine?: boolean;
 }
 
 // ============================================================
@@ -537,6 +541,99 @@ export interface PostDetailResponse {
   user: PostUser;
   spots: SpotWithTopSolution[];
   comment_count: number;
+  /** 좋아요 개수 */
+  like_count?: number;
+  /** 현재 사용자가 좋아요 했는지 (인증 시에만) */
+  user_has_liked?: boolean | null;
+  /** 현재 사용자가 저장했는지 (인증 시에만) */
+  user_has_saved?: boolean | null;
+  /** 연결된 Post Magazine ID (매거진이 생성된 경우) */
+  post_magazine_id?: string | null;
+  /** AI가 생성한 포스트 요약 (1-2문장) */
+  ai_summary?: string | null;
+}
+
+// ============================================================
+// Post Magazine API Types
+// GET /api/v1/post-magazines/{id}
+// ============================================================
+
+export interface PostMagazineDesignSpec {
+  accent_color: string;
+  primary_color?: string;
+  secondary_color?: string;
+  bg_color?: string;
+  font_heading?: string;
+  font_body?: string;
+  style_tags?: string[];
+}
+
+export interface PostMagazineEditorialSection {
+  paragraphs: string[];
+  pull_quote: string | null;
+}
+
+export interface PostMagazineCelebWithItem {
+  celeb_name: string;
+  celeb_image_url: string | null;
+  post_id: string;
+  item_name: string;
+  item_brand: string | null;
+  relevance_score: number;
+}
+
+export interface PostMagazineSpotItem {
+  spot_id: string;
+  solution_id: string | null;
+  title: string;
+  brand: string | null;
+  image_url: string | null;
+  original_url: string | null;
+  metadata: Record<string, unknown>;
+  editorial_paragraphs: string[];
+}
+
+export interface PostMagazineRelatedItem {
+  title: string;
+  brand: string | null;
+  image_url: string | null;
+  original_url: string | null;
+  relevance_reason: string | null;
+  source: "internal" | "external";
+  for_spot_id?: string | null;
+}
+
+export interface RelatedEditorialItem {
+  post_id: string;
+  title: string;
+  image_url?: string | null;
+  bg_color?: string | null;
+}
+
+export interface PostMagazineLayout {
+  schema_version: string;
+  title: string;
+  subtitle: string | null;
+  editorial: PostMagazineEditorialSection;
+  celeb_list: PostMagazineCelebWithItem[];
+  items: PostMagazineSpotItem[];
+  related_items: PostMagazineRelatedItem[];
+  design_spec: PostMagazineDesignSpec;
+}
+
+export interface PostMagazineResponse {
+  id: string;
+  title: string;
+  subtitle: string | null;
+  keyword: string | null;
+  layout_json: PostMagazineLayout | null;
+  status: string;
+  review_summary: string | null;
+  error_log: unknown | null;
+  created_at: string;
+  updated_at: string;
+  published_at: string | null;
+  related_editorials?: RelatedEditorialItem[];
 }
 
 // ============================================================

--- a/packages/web/lib/components/MobileNavBar.tsx
+++ b/packages/web/lib/components/MobileNavBar.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useState, useCallback } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { Home, Search, PlusCircle, User } from "lucide-react";
+import { Home, Search, BookOpen, PlusCircle, User } from "lucide-react";
 import { NavBar, NavItem } from "@/lib/design-system";
 import { RequestModal } from "./request/RequestModal";
 import { useAuthStore } from "@/lib/stores/authStore";
@@ -23,6 +23,7 @@ interface NavItemConfig {
 const navItems: NavItemConfig[] = [
   { id: "home", href: "/", icon: Home, label: "Home" },
   { id: "search", href: "/search", icon: Search, label: "Search" },
+  { id: "editorial", href: "/editorial", icon: BookOpen, label: "Editorial" },
   {
     id: "request",
     href: "#",

--- a/packages/web/lib/components/ThiingsGrid.tsx
+++ b/packages/web/lib/components/ThiingsGrid.tsx
@@ -105,6 +105,8 @@ export type GridItem = {
   postSource: PostSource; // Discriminator: "post" | "legacy"
   postAccount: string; // Account name for badge display (e.g., "newjeanscloset", "Legacy")
   postCreatedAt: string; // Post timestamp for context/sorting
+  /** 에디토리얼 그리드 카드 오버레이 표시용 */
+  editorialTitle?: string | null;
 };
 
 type GridItemInternal = {

--- a/packages/web/lib/components/detail/AISummarySection.tsx
+++ b/packages/web/lib/components/detail/AISummarySection.tsx
@@ -3,102 +3,29 @@
 import { useEffect, useState } from "react";
 
 type Props = {
-  summary?: string | null;
+  summary: string;
   isModal?: boolean;
 };
 
-/**
- * AI Summary block with generating animation.
- * Shows animated "AI is generating summary" state, then displays summary when ready.
- */
 export function AISummarySection({ summary, isModal = false }: Props) {
-  const [showSummary, setShowSummary] = useState(false);
-  const [dots, setDots] = useState("");
+  const [revealed, setRevealed] = useState(false);
 
-  // Simulate AI "thinking" - show summary after a delay if we have it
   useEffect(() => {
-    if (!summary) return;
-
-    const delay = 2200;
-    const t = setTimeout(() => setShowSummary(true), delay);
+    const t = setTimeout(() => setRevealed(true), 300);
     return () => clearTimeout(t);
-  }, [summary]);
-
-  // Typing dots animation
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setDots((d) => (d.length >= 3 ? "" : d + "."));
-    }, 400);
-    return () => clearInterval(interval);
   }, []);
 
   return (
     <div className="flex flex-col w-full">
-      <span className="font-sans text-[9px] md:text-[10px] uppercase tracking-[0.3em] text-primary/60 font-bold mb-6 block">
-        AI Summary
-      </span>
-
-      {showSummary && summary ? (
-        <div
-          className={`relative overflow-hidden rounded-sm border border-border/40 bg-muted/5 p-6 md:p-8 w-full transition-opacity duration-500 ${isModal ? "" : ""}`}
+      <div
+        className={`relative overflow-hidden rounded-sm border border-border/40 bg-muted/5 p-6 md:p-8 w-full transition-opacity duration-700 ${revealed ? "opacity-100" : "opacity-0"}`}
+      >
+        <p
+          className={`font-serif italic leading-relaxed text-foreground/90 ${isModal ? "text-base md:text-lg" : "text-lg md:text-xl"}`}
         >
-          <p
-            className={`font-serif italic leading-relaxed text-foreground/90 ${isModal ? "text-base md:text-lg" : "text-lg md:text-xl"}`}
-          >
-            &ldquo;{summary}&rdquo;
-          </p>
-        </div>
-      ) : (
-        <div
-          className={`relative overflow-hidden rounded-sm border border-border/40 bg-muted/5 p-6 md:p-8 w-full ${isModal ? "" : ""}`}
-        >
-          {/* Shimmer / generating animation */}
-          <div className="flex flex-col gap-4">
-            <div className="flex items-center gap-2">
-              <span className="font-serif italic text-foreground/60">
-                Generating summary
-              </span>
-              <span className="font-mono text-foreground/40 tabular-nums w-6">
-                {dots}
-              </span>
-            </div>
-            <div className="space-y-3 overflow-hidden">
-              <div className="h-3 w-full rounded bg-muted/40 overflow-hidden">
-                <div
-                  className="h-full w-1/2 bg-gradient-to-r from-transparent via-primary/15 to-transparent animate-shimmer"
-                  style={{ minWidth: "120px" }}
-                />
-              </div>
-              <div className="h-3 w-[85%] rounded bg-muted/30 overflow-hidden">
-                <div
-                  className="h-full w-1/2 bg-gradient-to-r from-transparent via-primary/12 to-transparent animate-shimmer"
-                  style={{ minWidth: "100px", animationDelay: "0.2s" }}
-                />
-              </div>
-              <div className="h-3 w-[70%] rounded bg-muted/20 overflow-hidden">
-                <div
-                  className="h-full w-1/2 bg-gradient-to-r from-transparent via-primary/10 to-transparent animate-shimmer"
-                  style={{ minWidth: "80px", animationDelay: "0.4s" }}
-                />
-              </div>
-            </div>
-            <div className="flex items-center gap-2 mt-4">
-              <div className="flex gap-1">
-                {[0, 1, 2].map((i) => (
-                  <div
-                    key={i}
-                    className="w-1.5 h-1.5 rounded-full bg-primary/40 animate-pulse"
-                    style={{ animationDelay: `${i * 0.15}s` }}
-                  />
-                ))}
-              </div>
-              <span className="text-[10px] uppercase tracking-widest text-muted-foreground/50">
-                Analyzing look
-              </span>
-            </div>
-          </div>
-        </div>
-      )}
+          &ldquo;{summary}&rdquo;
+        </p>
+      </div>
     </div>
   );
 }

--- a/packages/web/lib/components/detail/ImageCommentSection.tsx
+++ b/packages/web/lib/components/detail/ImageCommentSection.tsx
@@ -5,16 +5,22 @@ import { cn } from "@/lib/utils";
 
 interface ImageCommentSectionProps {
   imageId: string;
+  currentUserId?: string | null;
   className?: string;
 }
 
 export function ImageCommentSection({
-  imageId: _imageId,
+  imageId,
+  currentUserId,
   className,
 }: ImageCommentSectionProps) {
   return (
     <div className={cn("px-6 py-8 md:px-10 border-t border-border", className)}>
-      <CommentSection title="Comments" />
+      <CommentSection
+        postId={imageId}
+        title="Comments"
+        currentUserId={currentUserId}
+      />
     </div>
   );
 }

--- a/packages/web/lib/components/detail/ImageDetailContent.tsx
+++ b/packages/web/lib/components/detail/ImageDetailContent.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { RefObject, useMemo, useState } from "react";
+import { RefObject, useCallback, useMemo, useRef, useState } from "react";
 import type { ImageDetail } from "@/lib/supabase/queries/images";
 import type { ImageDetailWithPostOwner } from "@/lib/api/adapters/postDetailToImageDetail";
+import type { PostMagazineLayout, RelatedEditorialItem } from "@/lib/api/types";
 import type { Json } from "@/lib/supabase/types";
 import { normalizeItem, solutionToShopItem } from "./types";
 import type { UiItem } from "./types";
@@ -15,17 +16,28 @@ import { ImageCommentSection } from "./ImageCommentSection";
 import { AddSolutionSheet } from "./AddSolutionSheet";
 import { AISummarySection } from "./AISummarySection";
 import { useAllSolutionsForSpots } from "@/lib/hooks/useSolutions";
+import { useCommentCount } from "@/lib/hooks/useComments";
+import { usePostLike } from "@/lib/hooks/usePostLike";
+import { useSavedPost } from "@/lib/hooks/useSavedPost";
+import Image from "next/image";
+import {
+  MagazineEditorialSection,
+  MagazineCelebSection,
+  MagazineItemsSection,
+  MagazineRelatedSection,
+} from "./magazine";
+import { MagazineTitleSection } from "./magazine/MagazineTitleSection";
+import { SpotDot } from "./SpotDot";
 
 type Props = {
-  image: ImageDetail;
+  image: ImageDetail & { ai_summary?: string | null };
+  magazineLayout?: PostMagazineLayout | null;
+  relatedEditorials?: RelatedEditorialItem[];
   isModal?: boolean;
   scrollContainerRef?: RefObject<HTMLElement>;
-  // Controlled active index state (optional, for lifting state up)
   activeIndex?: number | null;
   onActiveIndexChange?: (index: number | null) => void;
-  // If true, hides the hero/interactive image (useful for modal split layout where image is external)
   hideImage?: boolean;
-  // Callback when hero image is clicked (for opening lightbox)
   onHeroClick?: () => void;
 };
 
@@ -40,6 +52,8 @@ type Props = {
  */
 export function ImageDetailContent({
   image,
+  magazineLayout,
+  relatedEditorials,
   isModal = false,
   scrollContainerRef,
   activeIndex,
@@ -47,6 +61,72 @@ export function ImageDetailContent({
   hideImage = false,
   onHeroClick,
 }: Props) {
+  const hasMagazine = !!magazineLayout;
+  const accentColor = magazineLayout?.design_spec?.accent_color;
+  const commentSectionRef = useRef<HTMLDivElement>(null);
+
+  const handleShare = useCallback(async () => {
+    const url =
+      typeof window !== "undefined"
+        ? `${window.location.origin}/posts/${image.id}`
+        : "";
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: "Post", url });
+        return;
+      } catch (err) {
+        if ((err as Error).name !== "AbortError") console.error(err);
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  }, [image.id]);
+
+  const scrollToComments = useCallback(() => {
+    commentSectionRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  const imageWithOwner = image as ImageDetailWithPostOwner;
+  const likeCount = imageWithOwner.like_count ?? 0;
+  const initialLiked = imageWithOwner.user_has_liked ?? false;
+  const initialSaved = imageWithOwner.user_has_saved ?? false;
+
+  const { like, unlike } = usePostLike(image.id);
+  const { save, unsave } = useSavedPost(image.id);
+
+  const handleLike = useCallback(
+    async (nextLiked: boolean) => {
+      try {
+        if (nextLiked) {
+          await like();
+        } else {
+          await unlike();
+        }
+      } catch (err) {
+        console.error("Like error:", err);
+      }
+    },
+    [like, unlike]
+  );
+
+  const handleSave = useCallback(
+    async (nextSaved: boolean) => {
+      try {
+        if (nextSaved) {
+          await save();
+        } else {
+          await unsave();
+        }
+      } catch (err) {
+        console.error("Save error:", err);
+      }
+    },
+    [save, unsave]
+  );
+
   // Items are now pre-fetched via post.item_ids (if post_image exists)
   // Fallback to item.image_id if no post_image found
   const items = image.items || [];
@@ -55,20 +135,7 @@ export function ImageDetailContent({
   const itemsFromPost = image.postImages && image.postImages.length > 0;
 
   const firstPost = image.postImages?.[0]?.post || image.posts?.[0];
-  const metadata = firstPost?.metadata;
-
-  // Extract Anchor from metadata
-  const anchor = useMemo(() => {
-    if (!metadata) return null;
-    const anchorTag = metadata.find(
-      (tag) =>
-        tag.toLowerCase().startsWith("anchor:") ||
-        tag.toLowerCase().startsWith("summary:")
-    );
-    if (!anchorTag) return null;
-    // Remove "Anchor:" or "Summary:" prefix and trim
-    return anchorTag.replace(/^(anchor|summary):\s*/i, "").trim();
-  }, [metadata]);
+  const aiSummary = image.ai_summary ?? null;
 
   // Normalize items with coordinates
   // Use item_locations from the first post_image if available to override item centers
@@ -156,8 +223,14 @@ export function ImageDetailContent({
     null
   );
 
+  const commentCount = useCommentCount(image.id);
+
+  const magazineCssVars = accentColor
+    ? ({ "--magazine-accent": accentColor } as React.CSSProperties)
+    : undefined;
+
   return (
-    <div className="detail-content relative">
+    <div className="detail-content relative" style={magazineCssVars}>
       {/* Decorative Vertical Typography - Shown on desktop (Full Page & Modal) */}
       <div className="absolute left-4 top-1/2 -translate-y-1/2 hidden lg:block pointer-events-none select-none">
         <span className="font-serif text-[10px] uppercase tracking-[1em] text-primary/5 writing-mode-vertical-rl rotate-180 opacity-50">
@@ -165,35 +238,79 @@ export function ImageDetailContent({
         </span>
       </div>
 
-      {/* Section 1: Hero - Hidden if hideImage is true */}
-      {!hideImage && (
-        <HeroSection image={image} isModal={isModal} onClick={onHeroClick} />
+      {/* Section 1: Magazine Title (text header) or Hero Image */}
+      {hasMagazine ? (
+        <MagazineTitleSection
+          title={magazineLayout.title}
+          subtitle={magazineLayout.subtitle}
+        />
+      ) : (
+        !hideImage && (
+          <HeroSection image={image} isModal={isModal} onClick={onHeroClick} />
+        )
       )}
 
-      {/* AI Summary Section */}
-      <section
-        className={`mx-auto px-6 ${isModal ? "max-w-5xl pt-10 pb-8" : "max-w-6xl pt-20 pb-16"}`}
-      >
-        <div className="w-full">
-          <AISummarySection summary={anchor} isModal={isModal} />
-        </div>
-      </section>
+      {/* AI Summary Section — only rendered when summary exists */}
+      {aiSummary && (
+        <section
+          className={`mx-auto px-6 ${isModal ? "max-w-5xl pt-10 pb-8" : hasMagazine ? "max-w-6xl pt-4 pb-8" : "max-w-6xl pt-20 pb-16"}`}
+        >
+          <div className="w-full">
+            <AISummarySection summary={aiSummary} isModal={isModal} />
+          </div>
+        </section>
+      )}
 
-      {/* Section 2: Interactive Showcase (only if items with coordinates exist) */}
-      {hasItemsWithCoordinates && (
-        <InteractiveShowcase
-          image={image}
-          items={normalizedItems}
-          isModal={isModal}
-          scrollContainerRef={scrollContainerRef}
-          activeIndex={activeIndex}
-          onActiveIndexChange={onActiveIndexChange}
-          renderImage={!hideImage}
-          onAddSolution={(spotId) => setSpotIdToAddSolution(spotId)}
-          postOwnerId={
-            (image as ImageDetailWithPostOwner).post_owner_id ?? null
-          }
-        />
+      {/* Section 2: Interactive Showcase (non-magazine) or static post image with spot dots (magazine) */}
+      {hasMagazine ? (
+        image.image_url && (
+          <section className="mx-auto max-w-sm px-4 py-8 md:px-8 md:py-12">
+            <div className="relative overflow-hidden rounded-xl">
+              <Image
+                src={image.image_url}
+                alt="Post image"
+                width={384}
+                height={0}
+                className="h-auto w-full"
+                sizes="(max-width: 768px) 80vw, 384px"
+                priority
+              />
+              {/* Spot overlay dots */}
+              {normalizedItems.map((item) => {
+                if (!item.normalizedCenter) return null;
+                const meta = item.metadata as unknown as Record<string, unknown> | undefined;
+                return (
+                  <SpotDot
+                    key={item.id}
+                    mode="percent"
+                    x={item.normalizedCenter.x}
+                    y={item.normalizedCenter.y}
+                    label={item.product_name ?? ""}
+                    brand={meta?.brand as string | undefined}
+                    category={meta?.sub_category as string | undefined}
+                    accentColor={accentColor}
+                  />
+                );
+              })}
+            </div>
+          </section>
+        )
+      ) : (
+        hasItemsWithCoordinates && (
+          <InteractiveShowcase
+            image={image}
+            items={normalizedItems}
+            isModal={isModal}
+            scrollContainerRef={scrollContainerRef}
+            activeIndex={activeIndex}
+            onActiveIndexChange={onActiveIndexChange}
+            renderImage={!hideImage}
+            onAddSolution={(spotId) => setSpotIdToAddSolution(spotId)}
+            postOwnerId={
+              (image as ImageDetailWithPostOwner).post_owner_id ?? null
+            }
+          />
+        )
       )}
 
       {/* Add Solution Sheet - for items without product info */}
@@ -204,49 +321,86 @@ export function ImageDetailContent({
         onClose={() => setSpotIdToAddSolution(null)}
       />
 
-      {/* Section 3: Shop Grid (show if any items exist, even without coordinates) */}
-      {hasItems && (
-        <div>
-          {itemsFromPost && image.postImages && image.postImages.length > 0 && (
-            <div className="mx-auto max-w-6xl px-4 py-3 md:px-8">
-              <p className="text-sm text-muted-foreground">
-                Items from post: @{image.postImages[0].post.account}
-              </p>
+      {hasMagazine ? (
+        <>
+          {/* Magazine: Editorial Section */}
+          <MagazineEditorialSection
+            editorial={magazineLayout.editorial}
+            accentColor={accentColor}
+          />
+
+          {/* Magazine: Celebrity Style Archive */}
+          <MagazineCelebSection
+            celebs={magazineLayout.celeb_list}
+            accentColor={accentColor}
+          />
+
+          {/* Magazine: The Look + per-item Related Items */}
+          <MagazineItemsSection
+            items={magazineLayout.items}
+            relatedItems={magazineLayout.related_items}
+            accentColor={accentColor}
+          />
+        </>
+      ) : (
+        <>
+          {/* Shop Grid (show if any items exist, even without coordinates) */}
+          {hasItems && (
+            <div>
+              {itemsFromPost && image.postImages && image.postImages.length > 0 && (
+                <div className="mx-auto max-w-6xl px-4 py-3 md:px-8">
+                  <p className="text-sm text-muted-foreground">
+                    Items from post: @{image.postImages[0].post.account}
+                  </p>
+                </div>
+              )}
+              <ShopGrid
+                items={solutionsLoading ? normalizedItems : shopItems}
+                isModal={isModal}
+                postId={image.id}
+                onAddSolutionClick={(spotId) => setSpotIdToAddSolution(spotId)}
+              />
             </div>
           )}
-          <ShopGrid
-            items={solutionsLoading ? normalizedItems : shopItems}
-            isModal={isModal}
-            postId={image.id}
-            onAddSolutionClick={(spotId) => setSpotIdToAddSolution(spotId)}
-          />
-        </div>
+        </>
       )}
 
-      {/* Related Images Section - Always show if account is available */}
+      {/* Related Posts - 같은 유저가 올린 다른 포스트 */}
       {image.postImages?.[0]?.post?.account && (
         <RelatedImages
           currentPostId={image.id}
           account={image.postImages[0].post.account}
+          userId={(image as ImageDetailWithPostOwner).post_owner_id ?? undefined}
           isModal={isModal}
         />
       )}
 
-      {/* ============================================================ */}
-      {/* Social Actions & Comments                                     */}
-      {/* ============================================================ */}
+      {/* Social Actions & Comments */}
       <div className="px-6 py-6 md:px-10 border-t border-border">
         <SocialActions
-          likeCount={42}
-          commentCount={3}
+          initialLiked={initialLiked}
+          initialSaved={initialSaved}
+          likeCount={likeCount}
+          commentCount={commentCount}
           showComment
           variant="default"
+          onLike={handleLike}
+          onSave={handleSave}
+          onShare={handleShare}
+          onComment={scrollToComments}
         />
       </div>
-      <ImageCommentSection imageId={image.id} />
+      <div ref={commentSectionRef}>
+        <ImageCommentSection imageId={image.id} />
+      </div>
+
+      {/* Magazine: Related Editorials - 맨 마지막 */}
+      {hasMagazine && relatedEditorials && relatedEditorials.length > 0 && (
+        <MagazineRelatedSection relatedEditorials={relatedEditorials} />
+      )}
 
       {/* Fallback: Show basic info if no items */}
-      {!hasItems && (
+      {!hasItems && !hasMagazine && (
         <div className="mx-auto max-w-4xl px-4 py-16 md:px-8">
           <div className="mb-8">
             <div className="mb-4 flex flex-wrap gap-2">

--- a/packages/web/lib/components/detail/ImageDetailModal.tsx
+++ b/packages/web/lib/components/detail/ImageDetailModal.tsx
@@ -5,10 +5,12 @@ import { useRouter } from "next/navigation";
 import { X, Maximize2 } from "lucide-react";
 import { gsap } from "gsap";
 import { Flip } from "gsap/Flip";
-import { usePostDetailForImage } from "@/lib/hooks/useImages";
-import { ImageDetailContent } from "./ImageDetailContent";
+import { usePostDetailForImage, usePostMagazine } from "@/lib/hooks/useImages";
+import { ImageDetailPreview } from "./ImageDetailPreview";
+import { SpotDot } from "./SpotDot";
 import { useTransitionStore } from "@/lib/stores/transitionStore";
 import { ReportErrorButton } from "./ReportErrorButton";
+import type { ImageDetailWithPostOwner } from "@/lib/api/adapters/postDetailToImageDetail";
 
 if (typeof window !== "undefined") {
   gsap.registerPlugin(Flip);
@@ -26,6 +28,8 @@ type Props = {
 export function ImageDetailModal({ imageId }: Props) {
   const router = useRouter();
   const { data: image, isLoading, error } = usePostDetailForImage(imageId);
+  const magazineId = (image as ImageDetailWithPostOwner)?.post_magazine_id;
+  const { data: magazine } = usePostMagazine(magazineId);
   const { originRect, reset, imgSrc } = useTransitionStore();
 
   // Debug: Log imageId and data state (development only)
@@ -432,11 +436,36 @@ export function ImageDetailModal({ imageId }: Props) {
       );
     }
 
+    const publishedMagazineLayout =
+      magazineId && magazine?.layout_json && magazine.status === "published"
+        ? magazine.layout_json
+        : null;
+
+    const magazineTitle = publishedMagazineLayout?.title ?? null;
+
+    const brands =
+      publishedMagazineLayout?.items
+        ?.map((item) => item.brand)
+        .filter((b): b is string => !!b && b.trim() !== "") ?? [];
+    const uniqueBrands = [...new Set(brands)];
+
+    const styleTags =
+      (publishedMagazineLayout?.design_spec as { style_tags?: string[] })
+        ?.style_tags ?? [];
+
+    const img = image as ImageDetailWithPostOwner;
+    const artistTags = [img?.artist_name, img?.group_name]
+      .filter((v): v is string => !!v && v.trim() !== "")
+      .filter((v, i, arr) => arr.indexOf(v) === i); // dedupe
+
     return (
-      <ImageDetailContent
+      <ImageDetailPreview
         image={image}
-        isModal={true}
-        scrollContainerRef={scrollContainerRef as React.RefObject<HTMLElement>}
+        magazineTitle={magazineTitle}
+        artistTags={artistTags}
+        brands={uniqueBrands}
+        styleTags={styleTags}
+        onViewFull={handleMaximize}
       />
     );
   };
@@ -573,13 +602,24 @@ export function ImageDetailModal({ imageId }: Props) {
       {activeImageSrc && (
         <div
           ref={leftImageContainerRef}
-          className="hidden md:block fixed z-60 shadow-2xl bg-black rounded-lg overflow-hidden"
+          className="hidden md:block fixed z-60 shadow-2xl rounded-lg overflow-hidden"
           style={{
             opacity: 0, // Initially hidden, set by GSAP
             // Initial positioning will be handled by GSAP based on originRect
           }}
           onWheel={handleImageScroll} // Forward scroll events
         >
+          {/* Blurred post image as background (letterbox fill) */}
+          <div
+            className="absolute inset-0 -z-10"
+            style={{
+              backgroundImage: `url(${activeImageSrc})`,
+              backgroundSize: "cover",
+              backgroundPosition: "center",
+              filter: "blur(24px)",
+              transform: "scale(1.08)",
+            }}
+          />
           <img
             ref={floatingImageRef}
             src={activeImageSrc}
@@ -594,10 +634,11 @@ export function ImageDetailModal({ imageId }: Props) {
             }}
           />
 
-          {/* Spot Markers on Floating Image (matching StyleCard white dot style) */}
+          {/* Spot Markers on Floating Image - with hover tooltip (brand, label, category) */}
           {image?.items && image.items.length > 0 && (() => {
             const imageRect = getContainedImageRect();
             if (!imageRect) return null;
+            const accentColor = (magazine?.layout_json as { design_spec?: { accent_color?: string } })?.design_spec?.accent_color;
 
             return (
               <div className="absolute inset-0 pointer-events-none z-20">
@@ -608,20 +649,21 @@ export function ImageDetailModal({ imageId }: Props) {
                   const fracY = typeof center[1] === "number" ? center[1] : parseFloat(String(center[1])) || 0;
                   const pixelLeft = imageRect.left + imageRect.width * (fracX > 1 ? fracX / 100 : fracX);
                   const pixelTop = imageRect.top + imageRect.height * (fracY > 1 ? fracY / 100 : fracY);
+                  const meta = item.metadata as unknown as Record<string, unknown> | undefined;
+                  const brand = meta?.brand as string | undefined;
+                  const category = meta?.sub_category as string | undefined;
 
                   return (
-                    <div
-                      key={item.spot_id ?? idx}
-                      className="absolute w-8 h-8 flex items-center justify-center"
-                      style={{
-                        left: `${pixelLeft}px`,
-                        top: `${pixelTop}px`,
-                        transform: "translate(-50%, -50%)",
-                      }}
-                    >
-                      <div className="absolute inset-0 bg-primary rounded-full animate-ping opacity-30 duration-[2000ms]" />
-                      <div className="relative w-3 h-3 bg-primary rounded-full shadow-[0_0_25px_oklch(0.9519_0.1739_115.8446)] border border-black/20" />
-                    </div>
+                    <SpotDot
+                      key={item.id ?? idx}
+                      mode="pixel"
+                      leftPx={pixelLeft}
+                      topPx={pixelTop}
+                      label={item.product_name ?? ""}
+                      brand={brand}
+                      category={category}
+                      accentColor={accentColor}
+                    />
                   );
                 })}
               </div>

--- a/packages/web/lib/components/detail/ImageDetailPage.tsx
+++ b/packages/web/lib/components/detail/ImageDetailPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePostDetailForImage } from "@/lib/hooks/useImages";
+import { usePostDetailForImage, usePostMagazine } from "@/lib/hooks/useImages";
 import { ImageDetailContent } from "./ImageDetailContent";
 import { LenisProvider } from "./LenisProvider";
 import { useEffect, useRef, useState } from "react";
@@ -10,6 +10,7 @@ import { X, Share2, Heart, Bookmark } from "lucide-react";
 import { ReportErrorButton } from "./ReportErrorButton";
 import { Lightbox } from "./Lightbox";
 import { ErrorState } from "@/lib/components/shared";
+import type { ImageDetailWithPostOwner } from "@/lib/api/adapters/postDetailToImageDetail";
 
 type Props = {
   imageId: string;
@@ -23,6 +24,8 @@ type Props = {
 export function ImageDetailPage({ imageId }: Props) {
   const router = useRouter();
   const { data: image, isLoading, error } = usePostDetailForImage(imageId);
+  const magazineId = (image as ImageDetailWithPostOwner)?.post_magazine_id;
+  const { data: magazine, isLoading: magazineLoading } = usePostMagazine(magazineId);
   const pageRef = useRef<HTMLDivElement>(null);
   const [showLightbox, setShowLightbox] = useState(false);
 
@@ -73,7 +76,9 @@ export function ImageDetailPage({ imageId }: Props) {
     }
   };
 
-  if (isLoading) {
+  const showMagazine = !!magazineId && !!magazine?.layout_json && magazine.status === "published";
+
+  if (isLoading || (magazineId && magazineLoading)) {
     return (
       <div
         className="flex min-h-screen items-center justify-center"
@@ -106,7 +111,7 @@ export function ImageDetailPage({ imageId }: Props) {
     <LenisProvider>
       <div ref={pageRef} className="relative">
         {/* Action Buttons */}
-        <div className="fixed right-4 top-4 z-50 flex gap-2">
+        <div className="fixed right-4 top-16 md:top-20 z-50 flex gap-2">
           <button
             className="flex h-10 w-10 items-center justify-center rounded-full bg-background/80 backdrop-blur-sm transition-transform transition-colors hover:scale-105 hover:bg-background/90"
             aria-label="Like"
@@ -136,7 +141,11 @@ export function ImageDetailPage({ imageId }: Props) {
           </button>
         </div>
 
-        <ImageDetailContent image={image} />
+        <ImageDetailContent
+          image={image}
+          magazineLayout={showMagazine ? magazine!.layout_json : null}
+          relatedEditorials={magazine?.related_editorials ?? []}
+        />
 
         {/* Lightbox */}
         <Lightbox

--- a/packages/web/lib/components/detail/ImageDetailPreview.tsx
+++ b/packages/web/lib/components/detail/ImageDetailPreview.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import Image from "next/image";
+import { Maximize2 } from "lucide-react";
+import { AISummarySection } from "./AISummarySection";
+
+type ImagePreviewProps = {
+  imageUrl: string;
+  alt?: string;
+};
+
+function ImagePreview({ imageUrl, alt = "Post" }: ImagePreviewProps) {
+  return (
+    <div className="relative aspect-[4/5] w-full overflow-hidden rounded-xl bg-muted md:max-w-sm">
+      <Image
+        src={imageUrl}
+        alt={alt}
+        fill
+        className="object-cover"
+        sizes="(max-width: 768px) 100vw, 384px"
+      />
+    </div>
+  );
+}
+
+type Props = {
+  image: {
+    id: string;
+    image_url?: string | null;
+    ai_summary?: string | null;
+    items?: { length: number } | unknown[];
+    postImages?: { post?: { account?: string } }[];
+  };
+  magazineTitle?: string | null;
+  artistTags?: string[];
+  brands?: string[];
+  styleTags?: string[];
+  onViewFull: () => void;
+};
+
+/**
+ * Lightweight preview for modal drawer.
+ * Order: image (mobile only) → 타이틀 → summary → 전체 에디토리얼 보기 CTA
+ */
+export function ImageDetailPreview({
+  image,
+  magazineTitle,
+  artistTags,
+  brands,
+  styleTags,
+  onViewFull,
+}: Props) {
+  const imageUrl =
+    (image as { image_url?: string }).image_url ??
+    (image as { postImages?: { post?: { image_url?: string } }[] })
+      ?.postImages?.[0]?.post?.image_url;
+
+  const aiSummary = (image as { ai_summary?: string | null }).ai_summary;
+  const itemCount = image.items?.length ?? 0;
+  const account =
+    (image.postImages?.[0]?.post?.account as string) || "unknown";
+
+  return (
+    <div className="flex flex-col gap-8 px-6 py-8 md:px-8 md:py-10">
+      {/* Image - mobile only (desktop has floating image) */}
+      <div className="block md:hidden">
+        {imageUrl && (
+          <ImagePreview imageUrl={imageUrl} alt={`Post by @${account}`} />
+        )}
+      </div>
+
+      {/* Magazine title (타이틀) */}
+      <div className="space-y-2">
+        {magazineTitle && (
+          <h2 className="font-serif text-2xl md:text-3xl font-semibold tracking-tight leading-tight">
+            {magazineTitle}
+          </h2>
+        )}
+        {itemCount > 0 && (
+          <p className="text-sm text-muted-foreground">
+            {itemCount}개의 아이템이 포함된 룩
+          </p>
+        )}
+        {((artistTags?.length ?? 0) > 0 || (brands?.length ?? 0) > 0 || (styleTags?.length ?? 0) > 0) && (
+          <div className="flex flex-wrap gap-2 pt-2">
+            {artistTags?.map((a) => (
+              <span
+                key={a}
+                className="rounded-full border border-border bg-foreground/10 px-2.5 py-1 text-xs font-medium text-foreground"
+              >
+                {a}
+              </span>
+            ))}
+            {brands?.map((b) => (
+              <span
+                key={b}
+                className="rounded-full border border-border bg-muted/30 px-2.5 py-1 text-xs font-medium text-foreground/80"
+              >
+                {b}
+              </span>
+            ))}
+            {styleTags?.map((s) => (
+              <span
+                key={s}
+                className="rounded-full border border-border/60 bg-muted/20 px-2.5 py-1 text-xs text-muted-foreground"
+              >
+                #{s}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* AI Summary */}
+      {aiSummary && (
+        <div className="w-full">
+          <AISummarySection summary={aiSummary} isModal />
+        </div>
+      )}
+
+      {/* CTA */}
+      <button
+        onClick={onViewFull}
+        className="flex w-full items-center justify-center gap-2 rounded-full border border-border bg-background px-6 py-3.5 text-sm font-medium transition-colors hover:bg-foreground hover:text-background"
+      >
+        <Maximize2 className="h-4 w-4" />
+        전체 에디토리얼 보기
+      </button>
+    </div>
+  );
+}

--- a/packages/web/lib/components/detail/RelatedImages.tsx
+++ b/packages/web/lib/components/detail/RelatedImages.tsx
@@ -7,7 +7,7 @@ import { useRef, useState } from "react";
 import { useGSAP } from "@gsap/react";
 import gsap from "gsap";
 import ScrollTrigger from "gsap/ScrollTrigger";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ArrowRight, ChevronDown, ChevronUp } from "lucide-react";
 
 // Register GSAP ScrollTrigger plugin
 if (typeof window !== "undefined") {
@@ -17,17 +17,22 @@ if (typeof window !== "undefined") {
 type Props = {
   currentPostId: string;
   account: string;
+  /** 같은 유저의 다른 포스트 조회용. 있으면 user_id로 필터, 없으면 artist_name(account) 시도 */
+  userId?: string | null;
   isModal?: boolean;
 };
 
 export function RelatedImages({
   currentPostId,
   account,
+  userId,
   isModal = false,
 }: Props) {
   const { data: postsData, isLoading } = useInfinitePosts({
     perPage: 12,
-    artistName: account,
+    // 같은 계정(유저)의 포스트 = user_id로 필터. artist_name은 셀럽명이라 account와 다름
+    userId: userId ?? undefined,
+    ...(userId ? {} : { artistName: account }),
   });
 
   const sectionRef = useRef<HTMLDivElement>(null);
@@ -164,10 +169,18 @@ export function RelatedImages({
                   </div>
                 )}
 
-                {/* Overlay with account name on hover */}
-                <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                  <div className="absolute bottom-3 left-3 text-white text-sm font-medium">
-                    @{account}
+                {/* Magazine-style overlay: artist_name의 N개의 아이템 둘러보기 + Read CTA */}
+                <div className="absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-black/70 via-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500">
+                  <div className="p-4 space-y-3">
+                    <p className="text-white/90 text-sm">
+                      {post.artist_name
+                        ? `${post.artist_name}의 아이템 둘러보기`
+                        : "아이템 둘러보기"}
+                    </p>
+                    <span className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-widest text-white/90 group-hover:text-white transition-colors border-b border-white/40 group-hover:border-white pb-0.5 w-fit">
+                      Read
+                      <ArrowRight className="h-3.5 w-3.5" />
+                    </span>
                   </div>
                 </div>
               </CardWrapper>

--- a/packages/web/lib/components/detail/SpotDot.tsx
+++ b/packages/web/lib/components/detail/SpotDot.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+
+type SpotDotProps = {
+  label: string;
+  brand?: string;
+  category?: string;
+  accentColor?: string;
+} & (
+  | { mode: "percent"; x: number; y: number }
+  | { mode: "pixel"; leftPx: number; topPx: number }
+);
+
+/**
+ * Spot marker with hover tooltip showing brand, label, category.
+ * Use mode="percent" for image-fill layouts, mode="pixel" for object-contain.
+ */
+export function SpotDot(props: SpotDotProps) {
+  const { label, brand, category, accentColor } = props;
+  const [hovered, setHovered] = useState(false);
+  const dotColor = accentColor || "hsl(var(--primary))";
+
+  const positionStyle =
+    props.mode === "percent"
+      ? {
+          left: `${props.x * 100}%`,
+          top: `${props.y * 100}%`,
+          transform: "translate(-50%, -50%)",
+        }
+      : {
+          left: `${props.leftPx}px`,
+          top: `${props.topPx}px`,
+          transform: "translate(-50%, -50%)",
+        };
+
+  return (
+    <div
+      className="absolute z-10 pointer-events-auto cursor-pointer"
+      style={positionStyle}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {/* Pulse ring */}
+      <span
+        className="absolute inset-0 animate-ping rounded-full opacity-30"
+        style={{ backgroundColor: dotColor, width: 20, height: 20, margin: -4 }}
+      />
+      {/* Dot */}
+      <span
+        className="relative block h-3 w-3 rounded-full border-2 border-white/80 shadow-md transition-transform duration-200"
+        style={{
+          backgroundColor: dotColor,
+          transform: hovered ? "scale(1.4)" : "scale(1)",
+        }}
+      />
+      {/* Tooltip - below dot to avoid clipping by overflow-hidden parent */}
+      {hovered && (
+        <div className="absolute left-1/2 top-full mt-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-background/95 px-3 py-1.5 text-xs shadow-lg border border-border/50 backdrop-blur-sm pointer-events-none z-[100]">
+          {brand && (
+            <span className="block text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              {brand}
+            </span>
+          )}
+          <span className="font-medium">{label}</span>
+          {category && (
+            <span className="block text-[10px] text-muted-foreground mt-0.5">
+              {category}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/lib/components/detail/magazine/MagazineCelebSection.tsx
+++ b/packages/web/lib/components/detail/magazine/MagazineCelebSection.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useRef } from "react";
+import { useGSAP } from "@gsap/react";
+import gsap from "gsap";
+import ScrollTrigger from "gsap/ScrollTrigger";
+import Image from "next/image";
+import Link from "next/link";
+import type { PostMagazineCelebWithItem } from "@/lib/api/types";
+
+if (typeof window !== "undefined") {
+  gsap.registerPlugin(ScrollTrigger);
+}
+
+type Props = {
+  celebs: PostMagazineCelebWithItem[];
+  accentColor?: string;
+};
+
+export function MagazineCelebSection({ celebs, accentColor }: Props) {
+  const sectionRef = useRef<HTMLDivElement>(null);
+
+  useGSAP(() => {
+    if (!sectionRef.current) return;
+
+    const cards = gsap.utils.toArray<HTMLElement>(
+      sectionRef.current.querySelectorAll(".celeb-card")
+    );
+
+    cards.forEach((card, i) => {
+      gsap.fromTo(
+        card,
+        { y: 40, opacity: 0 },
+        {
+          y: 0,
+          opacity: 1,
+          duration: 0.6,
+          delay: i * 0.1,
+          ease: "power2.out",
+          scrollTrigger: {
+            trigger: card,
+            start: "top 90%",
+            toggleActions: "play none none none",
+          },
+        }
+      );
+    });
+  });
+
+  if (celebs.length === 0) return null;
+
+  return (
+    <section ref={sectionRef} className="mx-auto max-w-5xl px-4 py-12 md:px-8 md:py-16">
+      <h2 className="typography-h3 mb-2 text-center">Style Archive</h2>
+      <p className="mb-10 text-center text-sm text-muted-foreground">
+        같은 아이템을 착용한 셀럽들
+      </p>
+
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5">
+        {celebs.map((celeb, i) => (
+          <Link
+            key={`${celeb.celeb_name}-${i}`}
+            href={`/posts/${celeb.post_id}`}
+            className="celeb-card group relative overflow-hidden rounded-xl border border-border/50 bg-card transition-all hover:border-border hover:shadow-lg"
+          >
+            <div className="relative aspect-[3/4] w-full overflow-hidden bg-muted">
+              {celeb.celeb_image_url ? (
+                <Image
+                  src={celeb.celeb_image_url}
+                  alt={celeb.celeb_name}
+                  fill
+                  className="object-cover transition-transform duration-500 group-hover:scale-105"
+                  sizes="(max-width: 768px) 50vw, 20vw"
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center">
+                  <span className="font-serif text-4xl text-muted-foreground/30">
+                    {celeb.celeb_name.charAt(0)}
+                  </span>
+                </div>
+              )}
+              <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
+            </div>
+
+            <div className="absolute bottom-0 left-0 right-0 p-3">
+              <p className="font-serif text-sm font-semibold text-white">
+                {celeb.celeb_name}
+              </p>
+              {celeb.item_brand && (
+                <p className="mt-0.5 text-xs text-white/70">
+                  {celeb.item_brand}
+                  {celeb.item_name ? ` — ${celeb.item_name}` : ""}
+                </p>
+              )}
+            </div>
+
+            <div
+              className="absolute right-2 top-2 rounded-full px-2 py-0.5 text-[10px] font-medium text-white/90 backdrop-blur-sm"
+              style={{
+                backgroundColor: accentColor
+                  ? `${accentColor}80`
+                  : "hsl(var(--primary) / 0.5)",
+              }}
+            >
+              View Post
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/web/lib/components/detail/magazine/MagazineContent.tsx
+++ b/packages/web/lib/components/detail/magazine/MagazineContent.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import type { PostMagazineLayout } from "@/lib/api/types";
+import { MagazineTitleSection } from "./MagazineTitleSection";
+import { MagazineEditorialSection } from "./MagazineEditorialSection";
+import { MagazineCelebSection } from "./MagazineCelebSection";
+import { MagazineItemsSection } from "./MagazineItemsSection";
+import type { RelatedEditorialItem } from "@/lib/api/types";
+import { MagazineRelatedSection } from "./MagazineRelatedSection";
+
+type Props = {
+  layout: PostMagazineLayout;
+  relatedEditorials?: RelatedEditorialItem[];
+};
+
+export function MagazineContent({ layout, relatedEditorials }: Props) {
+  const accentColor = layout.design_spec?.accent_color;
+
+  const cssVars = accentColor
+    ? ({ "--magazine-accent": accentColor } as React.CSSProperties)
+    : undefined;
+
+  return (
+    <div className="magazine-content relative" style={cssVars}>
+      {/* Decorative vertical typography */}
+      <div className="pointer-events-none absolute left-4 top-1/2 hidden -translate-y-1/2 select-none lg:block">
+        <span className="writing-mode-vertical-rl rotate-180 font-serif text-[10px] uppercase tracking-[1em] text-primary/5 opacity-50">
+          Decoded Editorial Archive
+        </span>
+      </div>
+
+      {/* Section 1: Title */}
+      <MagazineTitleSection
+        title={layout.title}
+        subtitle={layout.subtitle}
+      />
+
+      {/* Section 2: Editorial */}
+      <MagazineEditorialSection
+        editorial={layout.editorial}
+        accentColor={accentColor}
+      />
+
+      {/* Section 3: Celebrity List */}
+      <MagazineCelebSection
+        celebs={layout.celeb_list}
+        accentColor={accentColor}
+      />
+
+      {/* Section 4: Items + Item Editorial + per-item Related Items */}
+      <MagazineItemsSection
+        items={layout.items}
+        relatedItems={layout.related_items}
+        accentColor={accentColor}
+      />
+
+      {/* Section 6: Related Editorials */}
+      {relatedEditorials && relatedEditorials.length > 0 && (
+        <MagazineRelatedSection relatedEditorials={relatedEditorials} />
+      )}
+    </div>
+  );
+}

--- a/packages/web/lib/components/detail/magazine/MagazineEditorialSection.tsx
+++ b/packages/web/lib/components/detail/magazine/MagazineEditorialSection.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useGSAP } from "@gsap/react";
+import gsap from "gsap";
+import ScrollTrigger from "gsap/ScrollTrigger";
+import type { PostMagazineEditorialSection } from "@/lib/api/types";
+
+if (typeof window !== "undefined") {
+  gsap.registerPlugin(ScrollTrigger);
+}
+
+type Props = {
+  editorial: PostMagazineEditorialSection;
+  accentColor?: string;
+};
+
+export function MagazineEditorialSection({ editorial, accentColor }: Props) {
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const [isRevealed, setIsRevealed] = useState(false);
+
+  useEffect(() => {
+    const t = requestAnimationFrame(() => {
+      requestAnimationFrame(() => setIsRevealed(true));
+    });
+    return () => cancelAnimationFrame(t);
+  }, []);
+
+  useGSAP(() => {
+    if (!sectionRef.current) return;
+
+    const paragraphs = sectionRef.current.querySelectorAll(".editorial-p");
+    paragraphs.forEach((p) => {
+      gsap.fromTo(
+        p,
+        { y: 30, opacity: 0 },
+        {
+          y: 0,
+          opacity: 1,
+          duration: 0.8,
+          ease: "power2.out",
+          scrollTrigger: {
+            trigger: p,
+            start: "top 85%",
+            toggleActions: "play none none none",
+          },
+        }
+      );
+    });
+  });
+
+  const accentStyle = accentColor
+    ? ({ "--magazine-accent": accentColor } as React.CSSProperties)
+    : undefined;
+
+  return (
+    <section
+      ref={sectionRef}
+      style={accentStyle}
+      className={`mx-auto max-w-3xl px-4 py-12 md:px-8 md:py-16 overflow-hidden transition-opacity ${isRevealed ? "animate-ai-summary-reveal" : "opacity-0 invisible"}`}
+    >
+      <article className="space-y-6 md:space-y-8">
+        {editorial.paragraphs.map((text, i) => (
+          <p
+            key={i}
+            className={`editorial-p font-serif text-base leading-loose text-foreground md:text-lg ${
+              i === 0
+                ? "[&]:first-letter:text-6xl md:[&]:first-letter:text-7xl [&]:first-letter:font-serif [&]:first-letter:font-bold [&]:first-letter:mr-3 [&]:first-letter:float-left [&]:first-letter:text-foreground [&]:first-letter:leading-[0.8] [&]:first-letter:mt-2"
+                : ""
+            }`}
+          >
+            {text}
+          </p>
+        ))}
+      </article>
+
+      {editorial.pull_quote && (
+        <blockquote className="relative my-10 py-8 md:my-12">
+          <div
+            className="absolute left-0 top-0 h-0.5 w-12"
+            style={{
+              backgroundColor: accentColor
+                ? `${accentColor}4D`
+                : "var(--primary-30, hsl(var(--primary) / 0.3))",
+            }}
+          />
+          <p className="font-serif text-xl italic text-foreground md:text-2xl">
+            {editorial.pull_quote}
+          </p>
+          <div
+            className="absolute bottom-0 right-0 h-0.5 w-12"
+            style={{
+              backgroundColor: accentColor
+                ? `${accentColor}4D`
+                : "var(--primary-30, hsl(var(--primary) / 0.3))",
+            }}
+          />
+        </blockquote>
+      )}
+
+      <div className="mt-12 mb-8 flex items-center justify-center gap-4">
+        <div className="h-px w-12 bg-border/40" />
+        <div className="h-1.5 w-1.5 rounded-full bg-border/40" />
+        <div className="h-px w-12 bg-border/40" />
+      </div>
+    </section>
+  );
+}

--- a/packages/web/lib/components/detail/magazine/MagazineItemsSection.tsx
+++ b/packages/web/lib/components/detail/magazine/MagazineItemsSection.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useMemo, useRef } from "react";
+import { useGSAP } from "@gsap/react";
+import gsap from "gsap";
+import ScrollTrigger from "gsap/ScrollTrigger";
+import Image from "next/image";
+import { ExternalLink } from "lucide-react";
+import type {
+  PostMagazineSpotItem,
+  PostMagazineRelatedItem,
+} from "@/lib/api/types";
+
+if (typeof window !== "undefined") {
+  gsap.registerPlugin(ScrollTrigger);
+}
+
+type Props = {
+  items: PostMagazineSpotItem[];
+  relatedItems?: PostMagazineRelatedItem[];
+  accentColor?: string;
+};
+
+export function MagazineItemsSection({
+  items,
+  relatedItems = [],
+  accentColor,
+}: Props) {
+  const sectionRef = useRef<HTMLDivElement>(null);
+
+  const relatedBySpot = useMemo(() => {
+    const map = new Map<string, PostMagazineRelatedItem[]>();
+    for (const ri of relatedItems) {
+      if (!ri.for_spot_id) continue;
+      const list = map.get(ri.for_spot_id) ?? [];
+      list.push(ri);
+      map.set(ri.for_spot_id, list);
+    }
+    return map;
+  }, [relatedItems]);
+
+  useGSAP(() => {
+    if (!sectionRef.current) return;
+
+    const cards = gsap.utils.toArray<HTMLElement>(
+      sectionRef.current.querySelectorAll(".item-card")
+    );
+
+    cards.forEach((card, i) => {
+      gsap.fromTo(
+        card,
+        { y: 50, opacity: 0 },
+        {
+          y: 0,
+          opacity: 1,
+          duration: 0.7,
+          delay: i * 0.15,
+          ease: "power2.out",
+          scrollTrigger: {
+            trigger: card,
+            start: "top 85%",
+            toggleActions: "play none none none",
+          },
+        }
+      );
+    });
+  });
+
+  if (items.length === 0) return null;
+
+  return (
+    <section
+      ref={sectionRef}
+      className="mx-auto max-w-5xl px-4 py-12 md:px-8 md:py-16"
+    >
+      <h2 className="typography-h3 mb-2 text-center">The Look</h2>
+      <p className="mb-10 text-center text-sm text-muted-foreground">
+        아이템 상세 & 에디토리얼
+      </p>
+
+      <div className="space-y-12 md:space-y-16">
+        {items.map((item, i) => {
+          const meta = item.metadata as {
+            price?: string;
+            sub_category?: string;
+            material?: string[];
+          } | undefined;
+          const price = meta?.price;
+          const spotRelated = relatedBySpot.get(item.spot_id) ?? [];
+
+          return (
+            <div key={item.spot_id} className="item-card">
+              <div
+                className={`flex flex-col gap-6 md:flex-row md:gap-10 ${
+                  i % 2 === 1 ? "md:flex-row-reverse" : ""
+                }`}
+              >
+                {/* Item Image */}
+                <div className="relative aspect-square w-full shrink-0 overflow-hidden rounded-xl bg-muted md:w-72 lg:w-80">
+                  {item.image_url ? (
+                    <Image
+                      src={item.image_url}
+                      alt={item.title}
+                      fill
+                      className="object-cover"
+                      sizes="(max-width: 768px) 100vw, 320px"
+                    />
+                  ) : (
+                    <div
+                      className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center"
+                      style={{
+                        background: accentColor
+                          ? `linear-gradient(135deg, ${accentColor}18 0%, ${accentColor}08 100%)`
+                          : undefined,
+                      }}
+                    >
+                      <span className="text-[10px] font-bold uppercase tracking-[0.3em] text-muted-foreground/50">
+                        {(i + 1).toString().padStart(2, "0")}
+                      </span>
+                      {item.brand && (
+                        <span className="font-serif text-2xl font-light tracking-wide text-foreground/70 md:text-3xl">
+                          {item.brand}
+                        </span>
+                      )}
+                      {meta?.sub_category && (
+                        <span className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground/60">
+                          {meta.sub_category}
+                        </span>
+                      )}
+                      {meta?.material && meta.material.length > 0 && (
+                        <span className="text-[10px] italic text-muted-foreground/40">
+                          {meta.material.join(" · ")}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                {/* Item Details + Editorial */}
+                <div className="flex flex-1 flex-col justify-center">
+                  {item.brand && (
+                    <p className="typography-overline mb-2 text-muted-foreground">
+                      {item.brand}
+                    </p>
+                  )}
+                  <h3 className="typography-h4 mb-2">{item.title}</h3>
+                  {price && (
+                    <p className="mb-4 text-sm font-medium text-muted-foreground">
+                      {price}
+                    </p>
+                  )}
+
+                  {item.editorial_paragraphs.length > 0 && (
+                    <div className="mb-6 space-y-3">
+                      {item.editorial_paragraphs.map((p, j) => (
+                        <p
+                          key={j}
+                          className="font-serif text-sm leading-relaxed text-foreground/80 md:text-base"
+                        >
+                          {p}
+                        </p>
+                      ))}
+                    </div>
+                  )}
+
+                  {item.original_url && (
+                    <a
+                      href={item.original_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-2 rounded-full border border-border px-5 py-2.5 text-sm font-medium transition-colors hover:bg-foreground hover:text-background"
+                      style={
+                        accentColor
+                          ? { borderColor: `${accentColor}40` }
+                          : undefined
+                      }
+                    >
+                      Shop Now
+                      <ExternalLink className="h-3.5 w-3.5" />
+                    </a>
+                  )}
+                </div>
+              </div>
+
+              {/* Similar Items for this spot */}
+              {spotRelated.length > 0 && (
+                <div className="mt-6 ml-0 md:ml-[calc(18rem+2.5rem)] lg:ml-[calc(20rem+2.5rem)]">
+                  <p className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Similar Items
+                  </p>
+                  <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                    {spotRelated.slice(0, 3).map((ri, j) => (
+                      <a
+                        key={`${ri.title}-${j}`}
+                        href={ri.original_url ?? "#"}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group overflow-hidden rounded-lg border border-border/40 bg-card transition-all hover:border-border hover:shadow-md"
+                      >
+                        <div className="relative aspect-square w-full overflow-hidden bg-muted">
+                          {ri.image_url ? (
+                            <Image
+                              src={ri.image_url}
+                              alt={ri.title}
+                              fill
+                              className="object-cover transition-transform duration-500 group-hover:scale-105"
+                              sizes="(max-width: 640px) 50vw, 160px"
+                            />
+                          ) : (
+                            <div className="flex h-full items-center justify-center">
+                              <span className="text-2xl text-muted-foreground/20">
+                                {(j + 1).toString().padStart(2, "0")}
+                              </span>
+                            </div>
+                          )}
+                          <div
+                            className="absolute left-1.5 top-1.5 rounded-full px-1.5 py-0.5 text-[9px] font-medium backdrop-blur-sm"
+                            style={{
+                              backgroundColor:
+                                ri.source === "external"
+                                  ? accentColor
+                                    ? `${accentColor}80`
+                                    : "hsl(var(--primary) / 0.5)"
+                                  : "hsl(var(--muted) / 0.8)",
+                              color:
+                                ri.source === "external"
+                                  ? "white"
+                                  : "hsl(var(--muted-foreground))",
+                            }}
+                          >
+                            {ri.source === "external" ? "External" : "Internal"}
+                          </div>
+                        </div>
+                        <div className="p-2">
+                          {ri.brand && (
+                            <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                              {ri.brand}
+                            </p>
+                          )}
+                          <p className="mt-0.5 text-xs font-medium leading-snug line-clamp-2">
+                            {ri.title}
+                          </p>
+                        </div>
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/packages/web/lib/components/detail/magazine/MagazineRelatedSection.tsx
+++ b/packages/web/lib/components/detail/magazine/MagazineRelatedSection.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useRef } from "react";
+import { useGSAP } from "@gsap/react";
+import gsap from "gsap";
+import ScrollTrigger from "gsap/ScrollTrigger";
+import Image from "next/image";
+import { ArrowRight } from "lucide-react";
+import type { RelatedEditorialItem } from "@/lib/api/types";
+
+if (typeof window !== "undefined") {
+  gsap.registerPlugin(ScrollTrigger);
+}
+
+type Props = {
+  relatedEditorials: RelatedEditorialItem[];
+};
+
+export function MagazineRelatedSection({ relatedEditorials }: Props) {
+  const sectionRef = useRef<HTMLDivElement>(null);
+
+  useGSAP(() => {
+    if (!sectionRef.current) return;
+
+    gsap.fromTo(
+      sectionRef.current.querySelector(".related-content"),
+      { y: 60, opacity: 0 },
+      {
+        y: 0,
+        opacity: 1,
+        duration: 1,
+        ease: "power2.out",
+        scrollTrigger: {
+          trigger: sectionRef.current,
+          start: "top 70%",
+          toggleActions: "play none none none",
+        },
+      }
+    );
+  });
+
+  if (!relatedEditorials?.length) return null;
+
+  const [featured, ...rest] = relatedEditorials;
+  const bgColor = featured.bg_color || "#1f1f1f";
+
+  return (
+    <section
+      ref={sectionRef}
+      className="related-content mx-auto max-w-5xl border-t border-border/50 px-4 py-12 md:px-8 md:py-16"
+    >
+      <h2 className="typography-h3 mb-2 text-center">Related Editorials</h2>
+      <p className="mb-10 text-center text-sm text-muted-foreground">
+        같은 아티스트의 다른 에디토리얼
+      </p>
+
+      <div className="space-y-6 md:space-y-8">
+        {/* Featured (first) - use <a> for full page nav (avoid modal intercept) */}
+        <a
+          href={`/posts/${featured.post_id}`}
+          className="group/featured relative flex min-h-[32vh] flex-col items-center justify-center overflow-hidden rounded-2xl px-6 py-12 transition-transform hover:scale-[1.01]"
+          style={{ backgroundColor: bgColor }}
+        >
+          {featured.image_url && (
+            <Image
+              src={featured.image_url}
+              alt={featured.title || "Related editorial"}
+              fill
+              className="pointer-events-none object-cover opacity-30"
+              sizes="100vw"
+            />
+          )}
+          <div className="relative z-10 flex flex-col items-center gap-6">
+            {featured.title && (
+              <h2 className="typography-h2 max-w-2xl text-white">
+                {featured.title}
+              </h2>
+            )}
+            <span className="mt-4 inline-flex items-center gap-2 rounded-full border border-white/30 px-6 py-3 text-sm font-medium text-white transition-all group-hover/featured:bg-white group-hover/featured:text-black">
+              Read
+              <ArrowRight className="h-4 w-4" />
+            </span>
+          </div>
+        </a>
+
+        {/* Rest as grid */}
+        {rest.length > 0 && (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {rest.map((item) => (
+              <a
+                key={item.post_id}
+                href={`/posts/${item.post_id}`}
+                className="group relative flex min-h-[20rem] cursor-pointer flex-col justify-end overflow-hidden rounded-xl p-6 transition-transform hover:scale-[1.02]"
+                style={{
+                  backgroundColor: item.bg_color || "#1f1f1f",
+                }}
+              >
+                {item.image_url && (
+                  <Image
+                    src={item.image_url}
+                    alt={item.title || ""}
+                    fill
+                    className="pointer-events-none object-cover opacity-30 transition-opacity group-hover:opacity-50"
+                    sizes="(max-width: 640px) 100vw, 33vw"
+                  />
+                )}
+                <div className="relative z-10">
+                  <h3 className="typography-h4 max-w-md text-white line-clamp-2">
+                    {item.title}
+                  </h3>
+                  <span className="mt-2 inline-flex items-center gap-1 text-sm text-white/70 group-hover:text-white">
+                    Read
+                    <ArrowRight className="h-4 w-4" />
+                  </span>
+                </div>
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/web/lib/components/detail/magazine/MagazineTitleSection.tsx
+++ b/packages/web/lib/components/detail/magazine/MagazineTitleSection.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useRef } from "react";
+import { useGSAP } from "@gsap/react";
+import gsap from "gsap";
+
+type Props = {
+  title: string;
+  subtitle: string | null;
+};
+
+export function MagazineTitleSection({ title, subtitle }: Props) {
+  const sectionRef = useRef<HTMLDivElement>(null);
+
+  useGSAP(() => {
+    if (!sectionRef.current) return;
+
+    const tl = gsap.timeline();
+    tl.fromTo(
+      sectionRef.current.querySelector(".mag-overline"),
+      { y: 20, opacity: 0 },
+      { y: 0, opacity: 1, duration: 0.6, ease: "power2.out" }
+    )
+      .fromTo(
+        sectionRef.current.querySelector(".mag-title"),
+        { y: 40, opacity: 0 },
+        { y: 0, opacity: 1, duration: 0.8, ease: "power2.out" },
+        "-=0.3"
+      )
+      .fromTo(
+        sectionRef.current.querySelector(".mag-subtitle"),
+        { y: 20, opacity: 0 },
+        { y: 0, opacity: 1, duration: 0.6, ease: "power2.out" },
+        "-=0.4"
+      );
+  });
+
+  return (
+    <section
+      ref={sectionRef}
+      className="relative flex min-h-[25vh] flex-col items-center justify-center px-6 pt-16 pb-4 text-center md:pt-20 md:pb-6"
+    >
+      <p className="mag-overline typography-overline mb-6 text-muted-foreground opacity-0">
+        Editorial
+      </p>
+      <h1 className="mag-title typography-hero max-w-3xl opacity-0">{title}</h1>
+      {subtitle && (
+        <p className="mag-subtitle mt-6 max-w-xl text-lg font-light leading-relaxed text-muted-foreground opacity-0">
+          {subtitle}
+        </p>
+      )}
+      <div className="mt-12 flex items-center gap-4">
+        <div className="h-px w-12 bg-border/40" />
+        <div className="h-1.5 w-1.5 rounded-full bg-border/40" />
+        <div className="h-px w-12 bg-border/40" />
+      </div>
+    </section>
+  );
+}

--- a/packages/web/lib/components/detail/magazine/index.ts
+++ b/packages/web/lib/components/detail/magazine/index.ts
@@ -1,0 +1,5 @@
+export { MagazineContent } from "./MagazineContent";
+export { MagazineEditorialSection } from "./MagazineEditorialSection";
+export { MagazineCelebSection } from "./MagazineCelebSection";
+export { MagazineItemsSection } from "./MagazineItemsSection";
+export { MagazineRelatedSection } from "./MagazineRelatedSection";

--- a/packages/web/lib/components/explore/ExploreCardCell.tsx
+++ b/packages/web/lib/components/explore/ExploreCardCell.tsx
@@ -89,6 +89,27 @@ export const ExploreCardCell = memo(function ExploreCardCell({
             onError={() => setImageError(true)}
             onLoad={() => setIsLoaded(true)}
           />
+          {/* Editorial 타이틀 오버레이 - 검은 스킴 + 텍스트 아웃라인으로 어떤 배경에서도 선명하게 */}
+          {item?.editorialTitle && (
+            <div className="absolute inset-x-0 bottom-0">
+              {/* 하단 검은색 오버레이: 타이틀 영역 확실히 어둡게 */}
+              <div
+                className="absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-black/95 via-black/80 to-transparent"
+                aria-hidden
+              />
+              <div className="absolute inset-x-0 bottom-0 px-3.5 pb-3 pt-6">
+                <p
+                  className="line-clamp-2 text-[13px] font-semibold leading-[1.35] tracking-tight text-white antialiased"
+                  style={{
+                    textShadow:
+                      "0 0 2px rgba(0,0,0,1), 0 0 4px rgba(0,0,0,0.9), 0 1px 2px rgba(0,0,0,1), 0 2px 4px rgba(0,0,0,0.8), 0 2px 8px rgba(0,0,0,0.6)",
+                  }}
+                >
+                  {item.editorialTitle}
+                </p>
+              </div>
+            </div>
+          )}
         </article>
       </Card>
     </Link>

--- a/packages/web/lib/components/shared/CommentSection.tsx
+++ b/packages/web/lib/components/shared/CommentSection.tsx
@@ -1,181 +1,224 @@
 "use client";
 
 import { useState } from "react";
-import { Send, MoreHorizontal, ChevronDown, ChevronUp } from "lucide-react";
+import { Send, MoreHorizontal, ChevronDown, ChevronUp, Loader2, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AccountAvatar } from "./AccountAvatar";
 import { formatRelativeTime } from "@/lib/utils";
-
-export interface Comment {
-  id: string;
-  author: {
-    name: string;
-    avatar?: string;
-  };
-  text: string;
-  createdAt: string;
-  likes: number;
-  replies?: Comment[];
-}
+import {
+  useComments,
+  useCreateComment,
+  useDeleteComment,
+} from "@/lib/hooks/useComments";
+import type { CommentResponse } from "@/lib/api/comments";
 
 export interface CommentSectionProps {
-  comments?: Comment[];
+  postId: string;
   className?: string;
   title?: string;
+  currentUserId?: string | null;
 }
-
-const MOCK_COMMENTS: Comment[] = [
-  {
-    id: "1",
-    author: { name: "Minjae Kim" },
-    text: "Love this look! The styling is so on point.",
-    createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
-    likes: 12,
-    replies: [
-      {
-        id: "1-1",
-        author: { name: "Jiwoo Park" },
-        text: "Right? The accessories make the whole outfit.",
-        createdAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(),
-        likes: 3,
-      },
-    ],
-  },
-  {
-    id: "2",
-    author: { name: "Soyeon Lee" },
-    text: "Where can I find the jacket? Been looking everywhere!",
-    createdAt: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
-    likes: 8,
-  },
-  {
-    id: "3",
-    author: { name: "Hyunwoo Choi" },
-    text: "Great decode, very helpful for finding similar items.",
-    createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
-    likes: 5,
-  },
-];
 
 function CommentItem({
   comment,
+  postId,
+  currentUserId,
   depth = 0,
+  onReply,
 }: {
-  comment: Comment;
+  comment: CommentResponse;
+  postId: string;
+  currentUserId?: string | null;
   depth?: number;
+  onReply?: (parentId: string) => void;
 }) {
-  const [showReplies, setShowReplies] = useState(false);
+  const [showReplies, setShowReplies] = useState(true);
+  const deleteMutation = useDeleteComment(postId);
   const hasReplies = comment.replies && comment.replies.length > 0;
+  const displayName =
+    comment.user.display_name || comment.user.username || "User";
+  const createdAt = new Date(comment.created_at * 1000).toISOString();
+  const isOwner = currentUserId === comment.user_id;
 
   return (
     <div className={cn("flex gap-3", depth > 0 && "ml-10")}>
       <AccountAvatar
-        name={comment.author.name}
-        src={comment.author.avatar}
+        name={displayName}
+        src={comment.user.avatar_url ?? undefined}
         size="sm"
       />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium truncate">
-            {comment.author.name}
-          </span>
+          <span className="text-sm font-medium truncate">{displayName}</span>
           <span className="text-xs text-muted-foreground flex-shrink-0">
-            {formatRelativeTime(comment.createdAt)}
+            {formatRelativeTime(createdAt)}
           </span>
         </div>
-        <p className="text-sm text-foreground/90 mt-0.5">{comment.text}</p>
+        <p className="text-sm text-foreground/90 mt-0.5">{comment.content}</p>
         <div className="flex items-center gap-3 mt-1.5">
-          <button
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-            aria-label={`Like comment by ${comment.author.name}`}
-          >
-            Like ({comment.likes})
-          </button>
-          <button
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-            aria-label={`Reply to ${comment.author.name}`}
-          >
-            Reply
-          </button>
-          <button
-            className="p-0.5 text-muted-foreground hover:text-foreground transition-colors"
-            aria-label="More"
-          >
-            <MoreHorizontal className="h-3.5 w-3.5" />
-          </button>
+          {depth === 0 && onReply && (
+            <button
+              onClick={() => onReply(comment.id)}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Reply
+            </button>
+          )}
+          {isOwner && (
+            <button
+              onClick={() => deleteMutation.mutate(comment.id)}
+              disabled={deleteMutation.isPending}
+              className="text-xs text-muted-foreground hover:text-destructive transition-colors flex items-center gap-1"
+            >
+              <Trash2 className="h-3 w-3" />
+              Delete
+            </button>
+          )}
         </div>
 
         {hasReplies && (
-          <button
-            onClick={() => setShowReplies(!showReplies)}
-            className="flex items-center gap-1 mt-2 text-xs text-primary hover:text-primary/80 transition-colors"
-          >
-            {showReplies ? (
-              <ChevronUp className="h-3 w-3" />
-            ) : (
-              <ChevronDown className="h-3 w-3" />
-            )}
-            {showReplies
-              ? "Hide replies"
-              : `View ${comment.replies!.length} ${comment.replies!.length === 1 ? "reply" : "replies"}`}
-          </button>
+          <>
+            <button
+              onClick={() => setShowReplies(!showReplies)}
+              className="flex items-center gap-1 mt-2 text-xs text-primary hover:text-primary/80 transition-colors"
+            >
+              {showReplies ? (
+                <ChevronUp className="h-3 w-3" />
+              ) : (
+                <ChevronDown className="h-3 w-3" />
+              )}
+              {showReplies
+                ? "Hide replies"
+                : `View ${comment.replies.length} ${comment.replies.length === 1 ? "reply" : "replies"}`}
+            </button>
+            {showReplies &&
+              comment.replies.map((reply) => (
+                <div key={reply.id} className="mt-3">
+                  <CommentItem
+                    comment={reply}
+                    postId={postId}
+                    currentUserId={currentUserId}
+                    depth={depth + 1}
+                  />
+                </div>
+              ))}
+          </>
         )}
-
-        {showReplies &&
-          comment.replies?.map((reply) => (
-            <div key={reply.id} className="mt-3">
-              <CommentItem comment={reply} depth={depth + 1} />
-            </div>
-          ))}
       </div>
     </div>
   );
 }
 
 export function CommentSection({
-  comments = MOCK_COMMENTS,
+  postId,
   className,
   title = "Comments",
+  currentUserId,
 }: CommentSectionProps) {
+  const { data: comments, isLoading } = useComments(postId);
+  const createMutation = useCreateComment(postId);
   const [inputValue, setInputValue] = useState("");
+  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+
+  const handleSubmit = () => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+
+    createMutation.mutate(
+      { content: trimmed, parent_id: replyingTo },
+      {
+        onSuccess: () => {
+          setInputValue("");
+          setReplyingTo(null);
+        },
+      }
+    );
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  const commentCount = comments?.length ?? 0;
 
   return (
     <div className={cn("space-y-4", className)}>
       <h3 className="text-sm font-semibold">
-        {title} ({comments.length})
+        {title} ({commentCount})
       </h3>
 
       {/* Comment input */}
-      <div className="flex items-center gap-3">
-        <AccountAvatar name="You" size="sm" />
-        <div className="flex-1 relative">
-          <input
-            type="text"
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            placeholder="Add a comment..."
-            className="w-full rounded-full bg-muted px-4 py-2 pr-10 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-          />
-          <button
-            className={cn(
-              "absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-full transition-colors",
-              inputValue.trim()
-                ? "text-primary hover:bg-primary/10"
-                : "text-muted-foreground pointer-events-none"
-            )}
-            aria-label="Send comment"
-          >
-            <Send className="h-4 w-4" />
-          </button>
+      <div className="space-y-2">
+        {replyingTo && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span>Replying to comment</span>
+            <button
+              onClick={() => setReplyingTo(null)}
+              className="text-primary hover:underline"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+        <div className="flex items-center gap-3">
+          <AccountAvatar name="You" size="sm" />
+          <div className="flex-1 relative">
+            <input
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={
+                replyingTo ? "Write a reply..." : "Add a comment..."
+              }
+              className="w-full rounded-full bg-muted px-4 py-2 pr-10 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+            <button
+              onClick={handleSubmit}
+              disabled={!inputValue.trim() || createMutation.isPending}
+              className={cn(
+                "absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-full transition-colors",
+                inputValue.trim() && !createMutation.isPending
+                  ? "text-primary hover:bg-primary/10"
+                  : "text-muted-foreground pointer-events-none"
+              )}
+              aria-label="Send comment"
+            >
+              {createMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+            </button>
+          </div>
         </div>
       </div>
 
       {/* Comments list */}
-      <div className="space-y-4">
-        {comments.map((comment) => (
-          <CommentItem key={comment.id} comment={comment} />
-        ))}
-      </div>
+      {isLoading ? (
+        <div className="flex justify-center py-8">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      ) : comments && comments.length > 0 ? (
+        <div className="space-y-4">
+          {comments.map((comment) => (
+            <CommentItem
+              key={comment.id}
+              comment={comment}
+              postId={postId}
+              currentUserId={currentUserId}
+              onReply={(parentId) => setReplyingTo(parentId)}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground text-center py-6">
+          No comments yet. Be the first!
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/web/lib/components/shared/SocialActions.tsx
+++ b/packages/web/lib/components/shared/SocialActions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Heart, Bookmark, Share2, MessageCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -34,6 +34,12 @@ export function SocialActions({
   const [liked, setLiked] = useState(initialLiked);
   const [saved, setSaved] = useState(initialSaved);
   const [count, setCount] = useState(likeCount);
+
+  useEffect(() => {
+    setLiked(initialLiked);
+    setSaved(initialSaved);
+    setCount(likeCount);
+  }, [initialLiked, initialSaved, likeCount]);
 
   const handleLike = () => {
     const next = !liked;

--- a/packages/web/lib/components/shared/index.ts
+++ b/packages/web/lib/components/shared/index.ts
@@ -11,7 +11,7 @@ export { VotingButtons } from "./VotingButtons";
 export type { VotingButtonsProps } from "./VotingButtons";
 
 export { CommentSection } from "./CommentSection";
-export type { CommentSectionProps, Comment } from "./CommentSection";
+export type { CommentSectionProps } from "./CommentSection";
 
 export { ShareModal } from "./ShareModal";
 export type { ShareModalProps } from "./ShareModal";

--- a/packages/web/lib/design-system/desktop-header.tsx
+++ b/packages/web/lib/design-system/desktop-header.tsx
@@ -54,6 +54,7 @@ export interface DesktopHeaderProps
 const NAV_ITEMS = [
   { href: "/", label: "Home" },
   { href: "/explore", label: "Explore" },
+  { href: "/editorial", label: "Editorial" },
   { href: "/request/upload", label: "Upload", isUpload: true },
 ] as const;
 

--- a/packages/web/lib/hooks/useComments.ts
+++ b/packages/web/lib/hooks/useComments.ts
@@ -1,0 +1,55 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  fetchComments,
+  createComment,
+  deleteComment,
+  type CommentResponse,
+  type CreateCommentDto,
+} from "@/lib/api/comments";
+
+export const commentKeys = {
+  all: ["comments"] as const,
+  list: (postId: string) => [...commentKeys.all, "list", postId] as const,
+};
+
+export function useComments(postId: string) {
+  return useQuery({
+    queryKey: commentKeys.list(postId),
+    queryFn: () => fetchComments(postId),
+    enabled: !!postId,
+  });
+}
+
+export function useCreateComment(postId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (dto: CreateCommentDto) => createComment(postId, dto),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: commentKeys.list(postId) });
+    },
+  });
+}
+
+export function useDeleteComment(postId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (commentId: string) => deleteComment(commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: commentKeys.list(postId) });
+    },
+  });
+}
+
+function flatCount(comments: CommentResponse[]): number {
+  return comments.reduce(
+    (acc, c) => acc + 1 + (c.replies ? flatCount(c.replies) : 0),
+    0
+  );
+}
+
+export function useCommentCount(postId: string) {
+  const { data } = useComments(postId);
+  return data ? flatCount(data) : 0;
+}

--- a/packages/web/lib/hooks/useImages.ts
+++ b/packages/web/lib/hooks/useImages.ts
@@ -17,7 +17,7 @@ import {
   fetchUnifiedImages,
   fetchRelatedImagesByAccount,
 } from "@decoded/shared/supabase/queries/images";
-import { fetchPostDetail } from "@/lib/api/posts";
+import { fetchPosts, fetchPostDetail, fetchPostMagazine } from "@/lib/api/posts";
 import { postDetailToImageDetail } from "@/lib/api/adapters/postDetailToImageDetail";
 import type {
   CategoryFilter,
@@ -26,9 +26,7 @@ import type {
   ImageDetail,
   ImageRow,
 } from "@decoded/shared/supabase/queries/images";
-import { fetchPosts, fetchPostDetail } from "@/lib/api/posts";
-import { postDetailToImageDetail } from "@/lib/api/adapters/postDetailToImageDetail";
-import type { Post, PostsListParams } from "@/lib/api/types";
+import type { Post, PostsListParams, PostMagazineResponse } from "@/lib/api/types";
 
 /**
  * @deprecated Use useInfiniteFilteredImages with unified adapter instead.
@@ -37,21 +35,6 @@ export function useLatestImages(limit = 20) {
   return useQuery<ImageRow[]>({
     queryKey: ["images", "latest", limit],
     queryFn: () => fetchLatestImages(limit),
-  });
-}
-
-/**
- * React Query hook for fetching post detail via 백엔드 API
- * Explore/Feed는 post ID를 /posts/[id]로 전달하므로 API 사용
- */
-export function usePostDetailForImage(postId: string) {
-  return useQuery<ImageDetail | null>({
-    queryKey: ["posts", "detail", "image-view", postId],
-    queryFn: async () => {
-      const post = await fetchPostDetail(postId);
-      return postDetailToImageDetail(post, postId);
-    },
-    enabled: !!postId,
   });
 }
 
@@ -153,6 +136,8 @@ export type PostGridItem = {
   postCreatedAt: string;
   spotCount: number;
   viewCount: number;
+  /** 에디토리얼 그리드 오버레이용 (post.title 또는 post_magazine_title) */
+  title?: string | null;
 };
 
 /**
@@ -175,6 +160,7 @@ export function useInfinitePosts(params: {
   artistName?: string;
   groupName?: string;
   sort?: "recent" | "popular" | "trending";
+  hasMagazine?: boolean;
 }) {
   const {
     limit = 40,
@@ -183,13 +169,14 @@ export function useInfinitePosts(params: {
     artistName,
     groupName,
     sort = "recent",
+    hasMagazine,
   } = params;
 
   return useInfiniteQuery<PostsPage>({
     queryKey: [
       "posts",
       "infinite",
-      { category, search, artistName, groupName, sort, limit },
+      { category, search, artistName, groupName, sort, limit, hasMagazine },
     ],
     queryFn: async ({ pageParam }) => {
       const apiParams: PostsListParams = {
@@ -207,6 +194,9 @@ export function useInfinitePosts(params: {
       if (groupName) {
         apiParams.group_name = groupName;
       }
+      if (hasMagazine === true) {
+        apiParams.has_magazine = true;
+      }
 
       const response = await fetchPosts(apiParams);
 
@@ -220,6 +210,9 @@ export function useInfinitePosts(params: {
         postCreatedAt: post.created_at,
         spotCount: post.spot_count,
         viewCount: post.view_count,
+        // editorial 오버레이: 매거진 타이틀 우선, 없으면 post.title
+        title:
+          post.post_magazine_title ?? post.title ?? null,
       }));
 
       const { pagination } = response;
@@ -248,6 +241,23 @@ export function usePostDetailForImage(postId: string) {
     enabled: !!postId,
     staleTime: 1000 * 60,
     gcTime: 1000 * 60 * 5,
+  });
+}
+
+// ============================================================
+// Post Magazine hooks
+// ============================================================
+
+export function usePostMagazine(magazineId: string | null | undefined) {
+  return useQuery<PostMagazineResponse | null>({
+    queryKey: ["post-magazines", magazineId],
+    queryFn: async () => {
+      if (!magazineId) return null;
+      return fetchPostMagazine(magazineId);
+    },
+    enabled: !!magazineId,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
   });
 }
 

--- a/packages/web/lib/hooks/usePostLike.ts
+++ b/packages/web/lib/hooks/usePostLike.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  createPostLike,
+  deletePostLike,
+} from "@/lib/api/postLikes";
+
+const postDetailKey = (postId: string) =>
+  ["posts", "detail", "image", postId] as const;
+
+export function usePostLike(postId: string) {
+  const queryClient = useQueryClient();
+
+  const likeMutation = useMutation({
+    mutationFn: () => createPostLike(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postDetailKey(postId) });
+    },
+  });
+
+  const unlikeMutation = useMutation({
+    mutationFn: () => deletePostLike(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postDetailKey(postId) });
+    },
+  });
+
+  return {
+    like: likeMutation.mutateAsync,
+    unlike: unlikeMutation.mutateAsync,
+    isLiking: likeMutation.isPending,
+    isUnliking: unlikeMutation.isPending,
+    isPending: likeMutation.isPending || unlikeMutation.isPending,
+  };
+}

--- a/packages/web/lib/hooks/useSavedPost.ts
+++ b/packages/web/lib/hooks/useSavedPost.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { savePost, unsavePost } from "@/lib/api/savedPosts";
+
+const postDetailKey = (postId: string) =>
+  ["posts", "detail", "image", postId] as const;
+
+export function useSavedPost(postId: string) {
+  const queryClient = useQueryClient();
+
+  const saveMutation = useMutation({
+    mutationFn: () => savePost(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postDetailKey(postId) });
+    },
+  });
+
+  const unsaveMutation = useMutation({
+    mutationFn: () => unsavePost(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postDetailKey(postId) });
+    },
+  });
+
+  return {
+    save: saveMutation.mutateAsync,
+    unsave: unsaveMutation.mutateAsync,
+    isSaving: saveMutation.isPending,
+    isUnsaving: unsaveMutation.isPending,
+    isPending: saveMutation.isPending || unsaveMutation.isPending,
+  };
+}

--- a/packages/web/lib/utils/locale.ts
+++ b/packages/web/lib/utils/locale.ts
@@ -49,13 +49,31 @@ export function extractKoreanPart(
 }
 
 /**
+ * Normalize input to string array for filtering.
+ * Handles: string[], Record<string, unknown>, or other falsy values
+ */
+function toTagArray(tags: string[] | Record<string, unknown> | null | undefined): string[] {
+  if (!tags) return [];
+  if (Array.isArray(tags)) return tags.filter((t): t is string => typeof t === "string");
+  if (typeof tags === "object" && tags !== null && !Array.isArray(tags)) {
+    return Object.entries(tags)
+      .filter(([, v]) => v != null && v !== "")
+      .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(", ") : String(v)}`);
+  }
+  if (typeof tags === "string") return [tags];
+  return [];
+}
+
+/**
  * Filter tags to keep only those containing Korean characters
  * Also handles multi-language strings by extracting the Korean part
+ * Accepts string[] or Record<string, unknown> (metadata object)
  */
-export function filterKoreanTags(tags: string[] | null | undefined): string[] {
-  if (!tags) return [];
+export function filterKoreanTags(tags: string[] | Record<string, unknown> | null | undefined): string[] {
+  const arr = toTagArray(tags);
+  if (arr.length === 0) return [];
 
-  return tags
+  return arr
     .map((tag) => {
       // Use extractKoreanPart to handle both separators and pure Korean strings
       // (extractKoreanPart returns the string itself if it's Korean and has no separators,


### PR DESCRIPTION
## 변경 사항
- Editorial 페이지 및 네비게이션 (모바일/데스크톱) 추가
- Magazine API (`post-magazines`) 및 magazine 컴포넌트
- Like / Save / Comment API, 클라이언트, hooks
- Image detail UI 개선 (ImageDetailPreview, SpotDot 등)
- filterKoreanTags 유틸 개선

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: adds new proxy API routes and optional-auth header propagation, plus new mutations for likes/saves/comments that can affect user state and caching/invalidation behavior.
> 
> **Overview**
> Adds a new **Editorial** surface: `/editorial` tab (mobile + desktop nav) that reuses the explore grid but filters to posts with magazines (`has_magazine`) and shows an editorial title overlay.
> 
> Introduces **Post Magazine** support end-to-end: new `post-magazines` API proxy + client/types/hooks, and a magazine-style rendering path in post detail (title/editorial/celeb/items/related sections, accent-color theming, spot-dot overlays, and a lighter modal preview/CTA).
> 
> Implements **social actions** backed by real APIs: like/save proxy routes + client modules + React Query hooks, switches post detail to use API-provided `like_count`/`user_has_liked`/`user_has_saved`, and replaces mock comments with create/reply/delete flows and comment counting.
> 
> Also updates the shared API client and post detail proxy to attach `Authorization` when available (optional auth), and extends the post/detail adapter/types to include magazine and AI summary fields (with simplified AI summary reveal UI).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77fe0e8941b118f324a522048c15eb8362ba1fa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->